### PR TITLE
[chore] Set up global theme and font setup

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { CssBaseline, ThemeProvider } from '@mui/material'
 
 import App from './App.tsx'
+import '@/styles/index.css'
+import { theme } from '@/styles/theme'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/src/styles/font.ts
+++ b/src/styles/font.ts
@@ -1,0 +1,13 @@
+const systemSans = ['system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'] 
+
+export const fonts = {
+  body: ['Inter', ...systemSans].join(', '),
+  heading: ['Montserrat', ...systemSans].join(', '),
+}
+
+export const fontWeights = {
+  regular: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,35 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Montserrat:wght@500;600;700&display=swap');
+
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,63 @@
+import { createTheme } from '@mui/material/styles'
+
+import { fonts, fontWeights } from '@/styles/font'
+
+export const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#5E5549',
+    },
+    secondary: {
+      main: '#778984',
+    },
+    background: {
+      default: '#FDFCF8',
+      paper: '#FFFFFF',
+    },
+    text: {
+      primary: '#0f172a',
+      secondary: '#475569',
+    },
+  },
+  typography: {
+    fontFamily: fonts.body,
+    h1: {
+      fontFamily: fonts.heading,
+      fontWeight: fontWeights.bold,
+      letterSpacing: '-0.02em',
+    },
+    h2: {
+      fontFamily: fonts.heading,
+      fontWeight: fontWeights.bold,
+      letterSpacing: '-0.02em',
+    },
+    h3: {
+      fontFamily: fonts.heading,
+      fontWeight: fontWeights.semibold,
+      letterSpacing: '-0.02em',
+    },
+    h4: {
+      fontFamily: fonts.heading,
+      fontWeight: fontWeights.semibold,
+      letterSpacing: '-0.01em',
+    },
+    h5: {
+      fontFamily: fonts.heading,
+      fontWeight: fontWeights.semibold,
+      letterSpacing: '-0.01em',
+    },
+    h6: {
+      fontFamily: fonts.heading,
+      fontWeight: fontWeights.semibold,
+      letterSpacing: '-0.02em',
+    },
+    button: {
+      fontWeight: fontWeights.semibold,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 14,
+  },
+})


### PR DESCRIPTION
## Summary
Set up the initial global styling system for the app

## Changes
- added MUI theme configuration
- added shared font config
- set `Inter` as the default font and `Montserrat` for headings
- added global base styles
- applied theme through `ThemeProvider` and `CssBaseline`

## Palette
<img width="749" height="462" alt="image" src="https://github.com/user-attachments/assets/c964d743-fbff-4949-826e-fdd90df09065" />

- background: `#FDFCF8`
- primary: `#5E5549`
- secondary: `#778984`
- paper: `#FFFFFF`

