### PR TITLE
issue#11 Implement artwork submission page

### DIFF
--- a/functions/src/handlers/approveArtworkRegistration.ts
+++ b/functions/src/handlers/approveArtworkRegistration.ts
@@ -18,12 +18,12 @@ import { HttpError } from '../shared/httpError'
 import { PinataApiError, pinFileToIpfs } from '../shared/pinning'
 import { getUploadedObjectBytes } from '../shared/s3'
 import type { StoredArtworkDocument } from '../shared/types'
-import { validateRequiredString } from '../shared/validation'
 
 const ARTWORKS_COLLECTION = 'protectedArtworks'
 
 interface ApproveArtworkRequestBody {
   artworkId?: string
+  contentId?: string
 }
 
 export async function approveArtworkRegistrationHandler(
@@ -36,56 +36,45 @@ export async function approveArtworkRegistrationHandler(
 
   try {
     const body = request.body as ApproveArtworkRequestBody
-    const artworkId = validateRequiredString(body.artworkId, 'artworkId')
+    const artworkId = body.artworkId?.trim()
     const { uid: approvedBy } = await requireRoleFromHeader(
       request.header('authorization'),
       ['admin']
     )
 
+    if (!artworkId) {
+      throw new HttpError(400, 'artworkId is required.')
+    }
+
     const firestore = getFirestore()
-    const docRef = firestore.collection(ARTWORKS_COLLECTION).doc(artworkId)
-    const snapshot = await docRef.get()
 
-    if (!snapshot.exists) {
-      throw new HttpError(404, 'Artwork not found.')
-    }
+    const snapshots = await firestore
+      .collection(ARTWORKS_COLLECTION)
+      .where('artworkId', '==', artworkId)
+      .where('protection.status', '==', 'hashed')
+      .get()
 
-    const artwork = snapshot.data() as StoredArtworkDocument
-    if (artwork.protection.status === 'registered') {
-      response.status(200).json({
-        artworkId,
-        status: 'registered',
-        approvedBy: artwork.protection.approvedBy ?? approvedBy,
-      })
-      return
-    }
-
-    if (artwork.protection.status === 'chain_pending') {
-      response.status(200).json({
-        artworkId,
-        status: 'chain_pending',
-        approvedBy: artwork.protection.approvedBy ?? approvedBy,
-      })
-      return
-    }
-
-    if (artwork.protection.status !== 'hashed') {
+    if (snapshots.empty) {
       throw new HttpError(
-        409,
-        `Artwork must be hashed before approval. Current status: ${artwork.protection.status}`
+        404,
+        'No pending images found for this artwork. They may already be approved or no longer in hashed status.'
       )
     }
 
     const now = new Date().toISOString()
 
-    await docRef.update({
-      updatedAt: now,
-      'protection.approvedAt': now,
-      'protection.approvedBy': approvedBy,
-      'protection.errorCode': FieldValue.delete(),
-      'protection.errorMessage': FieldValue.delete(),
-      'protection.failedAt': FieldValue.delete(),
-    })
+    const updatePromises = snapshots.docs.map((doc) =>
+      doc.ref.update({
+        updatedAt: now,
+        'protection.approvedAt': now,
+        'protection.approvedBy': approvedBy,
+        'protection.errorCode': FieldValue.delete(),
+        'protection.errorMessage': FieldValue.delete(),
+        'protection.failedAt': FieldValue.delete(),
+      })
+    )
+
+    await Promise.all(updatePromises)
 
     response.status(200).json({
       artworkId,
@@ -93,7 +82,7 @@ export async function approveArtworkRegistrationHandler(
       approvedBy,
     })
 
-    // After approval, pin to IPFS and register on-chain asynchronously.
+    // Start async pin and register for all images
     void runPinAndRegisterArtworkAsync({ artworkId })
   } catch (error) {
     handleHttpError(response, error, 'Failed to approve artwork registration')
@@ -108,33 +97,55 @@ async function runPinAndRegisterArtworkAsync(
   params: PinAndRegisterArtworkParams
 ): Promise<void> {
   const firestore = getFirestore()
-  const docRef = firestore.collection(ARTWORKS_COLLECTION).doc(params.artworkId)
 
   try {
-    const snapshot = await docRef.get()
-    if (!snapshot.exists) {
-      logger.warn('Skip registration: artwork not found', {
+    // Get all content docs for this artworkId that are chain_pending or hashed
+    const snapshots = await firestore
+      .collection(ARTWORKS_COLLECTION)
+      .where('artworkId', '==', params.artworkId)
+      .where('protection.status', 'in', ['hashed', 'chain_pending'])
+      .get()
+
+    if (snapshots.empty) {
+      logger.info('No pending images to register', {
         artworkId: params.artworkId,
       })
       return
     }
 
-    const artwork = snapshot.data() as StoredArtworkDocument
+    logger.info('Starting registration for all images of artwork', {
+      artworkId: params.artworkId,
+      imageCount: snapshots.docs.length,
+    })
+
+    // Process each image sequentially to avoid resource contention
+    for (const doc of snapshots.docs) {
+      await registerSingleImageAsync(
+        firestore,
+        doc.data() as StoredArtworkDocument
+      )
+    }
+
+    // After all registrations, sync the artwork approval status
+    await syncArtworkApprovalStatus(firestore, params.artworkId)
+  } catch (error) {
+    logger.error('Batch registration failed', {
+      artworkId: params.artworkId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+async function registerSingleImageAsync(
+  firestore: ReturnType<typeof getFirestore>,
+  artwork: StoredArtworkDocument
+): Promise<void> {
+  const contentId = artwork.contentId ?? artwork.artworkId
+  const docRef = firestore.collection(ARTWORKS_COLLECTION).doc(contentId)
+
+  try {
     if (artwork.protection.status === 'registered') {
-      logger.info('Skip registration: already registered', {
-        artworkId: params.artworkId,
-      })
-      return
-    }
-
-    if (
-      artwork.protection.status !== 'hashed' &&
-      artwork.protection.status !== 'chain_pending'
-    ) {
-      logger.info('Skip registration: status is not ready for approval', {
-        artworkId: params.artworkId,
-        status: artwork.protection.status,
-      })
+      logger.info('Image already registered', { contentId })
       return
     }
 
@@ -155,7 +166,7 @@ async function runPinAndRegisterArtworkAsync(
       'protection.failedAt': FieldValue.delete(),
     })
 
-    // Step 1 after approval: Pin to IPFS
+    // Step 1: Pin to IPFS
     const s3Client = new S3Client({ region: artwork.protection.storage.region })
     const objectBytes = await getUploadedObjectBytes(
       s3Client,
@@ -170,7 +181,7 @@ async function runPinAndRegisterArtworkAsync(
       fileName: artwork.imageName,
       options: {
         keyValues: {
-          artworkId: params.artworkId,
+          artworkId: artwork.artworkId,
           imageHash: artwork.protection.imageHash,
         },
       },
@@ -178,15 +189,15 @@ async function runPinAndRegisterArtworkAsync(
 
     const ipfsCid = pinResult.IpfsHash
 
-    // Step 2 after approval: Register on blockchain
+    // Step 2: Register on blockchain
     const chainResult = await registerProtectionOnChain({
-      artworkId: params.artworkId,
+      artworkId: contentId,
       imageHash: artwork.protection.imageHash,
       ipfsCid,
       env: getBlockchainEnvConfig(),
     })
 
-    // Step 3 after approval: Update Firestore with all results
+    // Step 3: Update with all results
     const registeredAt = new Date().toISOString()
     await docRef.update({
       updatedAt: registeredAt,
@@ -199,10 +210,9 @@ async function runPinAndRegisterArtworkAsync(
       'protection.chainName': chainResult.chainName,
     })
 
-    logger.info('Artwork registration completed successfully', {
-      artworkId: params.artworkId,
-      imageHash: artwork.protection.imageHash,
-      ipfsCid,
+    logger.info('Image registration completed', {
+      contentId,
+      artworkId: artwork.artworkId,
       txHash: chainResult.txHash,
     })
   } catch (error) {
@@ -225,10 +235,51 @@ async function runPinAndRegisterArtworkAsync(
       'protection.errorMessage': errorMessage,
     })
 
-    logger.error('Artwork registration failed', {
-      artworkId: params.artworkId,
+    logger.error('Image registration failed', {
+      contentId,
       errorCode,
       errorMessage,
     })
   }
+}
+
+async function syncArtworkApprovalStatus(
+  firestore: ReturnType<typeof getFirestore>,
+  artworkId: string
+): Promise<void> {
+  if (!artworkId) {
+    return
+  }
+
+  const artworkSnapshot = await firestore
+    .collection('artworks')
+    .doc(artworkId)
+    .get()
+
+  if (!artworkSnapshot.exists) {
+    return
+  }
+
+  const protectedSnapshots = await firestore
+    .collection(ARTWORKS_COLLECTION)
+    .where('artworkId', '==', artworkId)
+    .get()
+
+  if (protectedSnapshots.empty) {
+    return
+  }
+
+  const hasUnregisteredContent = protectedSnapshots.docs.some((doc) => {
+    const artwork = doc.data() as StoredArtworkDocument
+    return artwork.protection.status !== 'registered'
+  })
+
+  if (hasUnregisteredContent) {
+    return
+  }
+
+  await firestore.collection('artworks').doc(artworkId).update({
+    status: 'approved',
+    updatedAt: new Date().toISOString(),
+  })
 }

--- a/functions/src/handlers/finalizeArtworkUpload.ts
+++ b/functions/src/handlers/finalizeArtworkUpload.ts
@@ -65,32 +65,14 @@ export async function finalizeArtworkUploadHandler(
     const submittedAt = new Date().toISOString()
 
     const firestore = getFirestore()
-    const docRef = firestore.collection(ARTWORKS_COLLECTION).doc(artworkId)
-
-    let effectiveSubmittedAt = submittedAt
-    let effectiveCreatedAt = submittedAt
+    const docRef = firestore.collection(ARTWORKS_COLLECTION).doc(contentId)
 
     await firestore.runTransaction(async (transaction) => {
       const snapshot = await transaction.get(docRef)
 
       if (snapshot.exists) {
-        const existing = snapshot.data() as Partial<StoredArtworkDocument>
-        if (existing.contentId && existing.contentId !== contentId) {
-          throw new HttpError(
-            409,
-            'Different contentId already exists for this artworkId.'
-          )
-        }
-
-        if (existing.ownerUid && existing.ownerUid !== ownerUid) {
-          throw new HttpError(403, 'Artwork owner mismatch.')
-        }
-
-        effectiveSubmittedAt =
-          typeof existing.submittedAt === 'string'
-            ? existing.submittedAt
-            : submittedAt
-        effectiveCreatedAt = existing.createdAt ?? submittedAt
+        logger.info('Content already finalized', { contentId, artworkId })
+        return
       }
 
       const payload: StoredArtworkDocument = {
@@ -103,9 +85,7 @@ export async function finalizeArtworkUploadHandler(
         protection: {
           status: 'uploaded',
           storage,
-          requestedAt:
-            (snapshot.data() as Partial<StoredArtworkDocument> | undefined)
-              ?.protection?.requestedAt ?? submittedAt,
+          requestedAt: submittedAt,
           uploadedAt: submittedAt,
           verifiedStorage: {
             objectKey: storage.objectKey,
@@ -120,12 +100,12 @@ export async function finalizeArtworkUploadHandler(
           contentLength,
           eTag: headResult.ETag ?? null,
         },
-        submittedAt: effectiveSubmittedAt,
-        createdAt: effectiveCreatedAt,
+        submittedAt,
+        createdAt: submittedAt,
         updatedAt: submittedAt,
       }
 
-      transaction.set(docRef, payload, { merge: true })
+      transaction.set(docRef, payload)
     })
 
     const result: FinalizeUploadResponseBody = {
@@ -136,13 +116,13 @@ export async function finalizeArtworkUploadHandler(
         contentType,
         contentLength,
       },
-      submittedAt: effectiveSubmittedAt,
+      submittedAt,
     }
 
     response.status(200).json(result)
 
     void runHashingPipelineAsync({
-      artworkId,
+      contentId,
       storage,
     })
   } catch (error) {
@@ -151,7 +131,7 @@ export async function finalizeArtworkUploadHandler(
 }
 
 interface HashingPipelineParams {
-  artworkId: string
+  contentId: string
   storage: S3StorageReference
 }
 
@@ -159,13 +139,13 @@ async function runHashingPipelineAsync(
   params: HashingPipelineParams
 ): Promise<void> {
   const firestore = getFirestore()
-  const docRef = firestore.collection(ARTWORKS_COLLECTION).doc(params.artworkId)
+  const docRef = firestore.collection(ARTWORKS_COLLECTION).doc(params.contentId)
 
   try {
     const snapshot = await docRef.get()
     if (!snapshot.exists) {
       logger.warn('Skip hashing pipeline: artwork not found', {
-        artworkId: params.artworkId,
+        contentId: params.contentId,
       })
       return
     }
@@ -173,14 +153,14 @@ async function runHashingPipelineAsync(
     const artwork = snapshot.data() as StoredArtworkDocument
     if (artwork.protection.status === 'hashed') {
       logger.info('Skip hashing pipeline: already hashed', {
-        artworkId: params.artworkId,
+        contentId: params.contentId,
       })
       return
     }
 
     if (artwork.protection.status !== 'uploaded') {
       logger.info('Skip hashing pipeline: status is not uploaded', {
-        artworkId: params.artworkId,
+        contentId: params.contentId,
         status: artwork.protection.status,
       })
       return
@@ -221,7 +201,7 @@ async function runHashingPipelineAsync(
     })
 
     logger.error('Hashing pipeline failed', {
-      artworkId: params.artworkId,
+      contentId: params.contentId,
       errorMessage,
     })
   }

--- a/functions/src/handlers/getArtworkProtectionStatus.ts
+++ b/functions/src/handlers/getArtworkProtectionStatus.ts
@@ -29,16 +29,17 @@ export async function getArtworkProtectionStatusHandler(
     const artworkId = validateRequiredString(body.artworkId, 'artworkId')
 
     const firestore = getFirestore()
-    const snapshot = await firestore
+    const snapshots = await firestore
       .collection(ARTWORKS_COLLECTION)
-      .doc(artworkId)
+      .where('artworkId', '==', artworkId)
       .get()
 
-    if (!snapshot.exists) {
-      throw new HttpError(404, 'Artwork not found.')
+    if (snapshots.empty) {
+      throw new HttpError(404, 'Artwork protection record not found.')
     }
 
-    const artwork = snapshot.data() as StoredArtworkDocument
+    const firstDoc = snapshots.docs[0]
+    const artwork = firstDoc.data() as StoredArtworkDocument
 
     response.status(200).json({
       id: artwork.artworkId,

--- a/functions/src/handlers/listPendingArtworkProtection.ts
+++ b/functions/src/handlers/listPendingArtworkProtection.ts
@@ -10,6 +10,19 @@ import type { StoredArtworkDocument } from '../shared/types'
 
 const ARTWORKS_COLLECTION = 'protectedArtworks'
 
+interface PendingArtworkGroup {
+  artworkId: string
+  title: string
+  ownerUid?: string
+  createdAt: string
+  updatedAt?: string
+  images: Array<{
+    contentId: string
+    imageName: string
+    status: string
+  }>
+}
+
 export async function listPendingArtworkProtectionHandler(
   request: HttpRequest,
   response: HttpResponse
@@ -25,19 +38,32 @@ export async function listPendingArtworkProtectionHandler(
       .where('protection.status', '==', 'hashed')
       .get()
 
-    const items = snapshots.docs.map((doc) => {
+    const grouped = new Map<string, PendingArtworkGroup>()
+
+    snapshots.docs.forEach((doc) => {
       const artwork = doc.data() as StoredArtworkDocument
-      return {
-        id: artwork.artworkId,
-        title: artwork.title,
-        imageName: artwork.imageName,
-        contentId: artwork.contentId,
-        ownerUid: artwork.ownerUid,
-        createdAt: artwork.createdAt,
-        updatedAt: artwork.updatedAt,
-        protection: artwork.protection,
+      const artworkId = artwork.artworkId || 'unknown'
+
+      if (!grouped.has(artworkId)) {
+        grouped.set(artworkId, {
+          artworkId,
+          title: artwork.title,
+          ownerUid: artwork.ownerUid,
+          createdAt: artwork.createdAt,
+          updatedAt: artwork.updatedAt,
+          images: [],
+        })
       }
+
+      const group = grouped.get(artworkId)!
+      group.images.push({
+        contentId: artwork.contentId ?? doc.id,
+        imageName: artwork.imageName,
+        status: artwork.protection.status,
+      })
     })
+
+    const items = Array.from(grouped.values())
 
     response.status(200).json({ items })
   } catch (error) {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -211,6 +211,15 @@ function Header() {
                     Edit profile
                   </MenuItem>
                   <MenuItem
+                    onClick={() => {
+                      closeProfileMenu()
+                      navigate('/artwork-management')
+                    }}
+                    sx={{ fontSize: '0.95rem', minHeight: 42, px: 2 }}
+                  >
+                    My artwork management
+                  </MenuItem>
+                  <MenuItem
                     onClick={handleLogout}
                     sx={{ fontSize: '0.95rem', minHeight: 42, px: 2 }}
                   >

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -10,6 +10,7 @@ import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { onAuthStateChanged } from 'firebase/auth'
+import { doc, getDoc } from 'firebase/firestore'
 
 import { DEFAULT_PROFILE_IMAGE_URL } from '@/constants/profileIcons'
 import {
@@ -17,7 +18,7 @@ import {
   AUTH_SESSION_UPDATED_EVENT,
   logout,
 } from '@/firebase/auth'
-import { auth } from '@/firebase/config'
+import { auth, db } from '@/firebase/config'
 
 const headerActionSx = {
   minHeight: 42,
@@ -39,6 +40,7 @@ function Header() {
   )
   const [profileMenuAnchor, setProfileMenuAnchor] =
     useState<HTMLElement | null>(null)
+  const [userRole, setUserRole] = useState<string | null>(null)
 
   const goToGallery = () => navigate('/gallery')
   const goToLogin = () => navigate('/login')
@@ -46,10 +48,22 @@ function Header() {
   const isProfileMenuOpen = Boolean(profileMenuAnchor)
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
       setIsLoggedIn(Boolean(user))
       setUsername(user?.displayName || user?.email || 'User')
       setProfileImageUrl(user?.photoURL || DEFAULT_PROFILE_IMAGE_URL)
+
+      if (user) {
+        try {
+          const userDoc = await getDoc(doc(db, 'users', user.uid))
+          setUserRole(userDoc.data()?.role ?? null)
+        } catch (error) {
+          console.error('Failed to fetch user role:', error)
+          setUserRole(null)
+        }
+      } else {
+        setUserRole(null)
+      }
     })
 
     return unsubscribe
@@ -210,15 +224,17 @@ function Header() {
                   >
                     Edit profile
                   </MenuItem>
-                  <MenuItem
-                    onClick={() => {
-                      closeProfileMenu()
-                      navigate('/artwork-management')
-                    }}
-                    sx={{ fontSize: '0.95rem', minHeight: 42, px: 2 }}
-                  >
-                    My artwork management
-                  </MenuItem>
+                  {userRole === 'student' ? (
+                    <MenuItem
+                      onClick={() => {
+                        closeProfileMenu()
+                        navigate('/artwork-management')
+                      }}
+                      sx={{ fontSize: '0.95rem', minHeight: 42, px: 2 }}
+                    >
+                      My artwork management
+                    </MenuItem>
+                  ) : null}
                   <MenuItem
                     onClick={handleLogout}
                     sx={{ fontSize: '0.95rem', minHeight: 42, px: 2 }}
@@ -243,21 +259,23 @@ function Header() {
               </ButtonBase>
             )}
 
-            <ButtonBase
-              onClick={goToSubmit}
-              sx={{
-                ...headerActionSx,
-                borderColor: 'primary.main',
-                backgroundColor: 'primary.main',
-                color: 'common.white',
-                '&:hover': {
-                  backgroundColor: 'primary.dark',
-                  borderColor: 'primary.dark',
-                },
-              }}
-            >
-              Submit work
-            </ButtonBase>
+            {isLoggedIn && userRole === 'student' ? (
+              <ButtonBase
+                onClick={goToSubmit}
+                sx={{
+                  ...headerActionSx,
+                  borderColor: 'primary.main',
+                  backgroundColor: 'primary.main',
+                  color: 'common.white',
+                  '&:hover': {
+                    backgroundColor: 'primary.dark',
+                    borderColor: 'primary.dark',
+                  },
+                }}
+              >
+                Submit work
+              </ButtonBase>
+            ) : null}
           </Stack>
         </Stack>
       </Box>

--- a/src/pages/AdminPage/index.tsx
+++ b/src/pages/AdminPage/index.tsx
@@ -12,7 +12,7 @@ import { doc, getDoc } from 'firebase/firestore'
 
 import { auth, db } from '@/firebase/config'
 import { contentContainerSx, contentPageSx } from '@/styles/page'
-import type { ProtectedArtworkRecord } from '@/types/blockchain'
+import type { PendingArtworkGroup } from '@/types/blockchain'
 import {
   requestApproveArtworkRegistration,
   requestPendingProtectedArtworks,
@@ -20,9 +20,9 @@ import {
 
 function AdminPage() {
   const navigate = useNavigate()
-  const [pendingArtworks, setPendingArtworks] = useState<
-    ProtectedArtworkRecord[]
-  >([])
+  const [pendingArtworks, setPendingArtworks] = useState<PendingArtworkGroup[]>(
+    []
+  )
   const [isLoading, setIsLoading] = useState(true)
   const [isApprovingArtworkId, setIsApprovingArtworkId] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
@@ -74,10 +74,13 @@ function AdminPage() {
       }
 
       const idToken = await currentUser.getIdToken()
-      await requestApproveArtworkRegistration({ artworkId, authToken: idToken })
+      await requestApproveArtworkRegistration({
+        artworkId,
+        authToken: idToken,
+      })
 
       setSuccessMessage(
-        `Artwork ${artworkId} approved. Chain registration is now running in background.`
+        `Artwork "${pendingArtworks.find((a) => a.artworkId === artworkId)?.title}" approved. Chain registration for all ${pendingArtworks.find((a) => a.artworkId === artworkId)?.images.length} images is now running in background.`
       )
       const artworks = await requestPendingProtectedArtworks()
       setPendingArtworks(artworks)
@@ -123,45 +126,110 @@ function AdminPage() {
         <Stack spacing={2}>
           {pendingArtworks.map((artwork) => (
             <Stack
-              key={artwork.id}
-              spacing={1.25}
+              key={artwork.artworkId}
+              spacing={1.5}
               sx={{
                 border: '1px solid',
                 borderColor: 'divider',
                 borderRadius: 2,
-                p: 2,
+                p: 3,
               }}
             >
-              <Typography variant="h6">
-                {artwork.title || 'Untitled artwork'}
-              </Typography>
-              <Typography color="text.secondary">
-                Artwork ID: {artwork.id}
-              </Typography>
-              <Typography color="text.secondary">
-                Owner: {artwork.ownerUid ?? 'Unknown'}
-              </Typography>
-              <Typography color="text.secondary">
-                Status: {artwork.protection.status}
-              </Typography>
-              <Typography color="text.secondary">
-                Requested at: {artwork.protection.requestedAt ?? 'Unknown'}
-              </Typography>
-              <Button
-                disabled={!isAdmin || isApprovingArtworkId === artwork.id}
-                onClick={() => void handleApprove(artwork.id)}
-                variant="contained"
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'flex-start',
+                }}
               >
-                {isApprovingArtworkId === artwork.id
-                  ? 'Approving...'
-                  : 'Approve'}
-              </Button>
-              <Button
-                onClick={() => navigate(`/artworks/${artwork.id}`)}
-                variant="outlined"
-              >
-                View detail
-              </Button>
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="h6" gutterBottom>
+                    {artwork.title || 'Untitled artwork'}
+                  </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Submission ID: {artwork.artworkId}
+                  </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Owner: {artwork.ownerUid ?? 'Unknown'}
+                  </Typography>
+                </Box>
+                <Typography
+                  variant="body2"
+                  sx={{
+                    backgroundColor: '#e3f2fd',
+                    px: 2,
+                    py: 0.75,
+                    borderRadius: 1,
+                    fontWeight: 500,
+                  }}
+                >
+                  {artwork.images.length} image
+                  {artwork.images.length !== 1 ? 's' : ''}
+                </Typography>
+              </Box>
+
+              <Stack spacing={1}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                  Images to register:
+                </Typography>
+                {artwork.images.map((image, idx) => (
+                  <Box
+                    key={`${artwork.artworkId}-${idx}`}
+                    sx={{
+                      p: 1.5,
+                      backgroundColor: '#f5f5f5',
+                      borderRadius: 1,
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Box>
+                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                        {image.imageName}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {image.contentId}
+                      </Typography>
+                    </Box>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        backgroundColor:
+                          image.status === 'hashed' ? '#fff3cd' : '#d4edda',
+                        px: 1.5,
+                        py: 0.5,
+                        borderRadius: 1,
+                        fontWeight: 500,
+                      }}
+                    >
+                      {image.status}
+                    </Typography>
+                  </Box>
+                ))}
+              </Stack>
+
+              <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
+                <Button
+                  disabled={
+                    !isAdmin || isApprovingArtworkId === artwork.artworkId
+                  }
+                  onClick={() => void handleApprove(artwork.artworkId)}
+                  variant="contained"
+                  sx={{ flex: 1 }}
+                >
+                  {isApprovingArtworkId === artwork.artworkId
+                    ? 'Approving...'
+                    : 'Approve all images'}
+                </Button>
+                <Button
+                  onClick={() => navigate(`/artworks/${artwork.artworkId}`)}
+                  variant="outlined"
+                  sx={{ flex: 1 }}
+                >
+                  View submission
+                </Button>
+              </Stack>
             </Stack>
           ))}
         </Stack>

--- a/src/pages/ArtworkManagementPage/index.tsx
+++ b/src/pages/ArtworkManagementPage/index.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Divider from '@mui/material/Divider'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Tab from '@mui/material/Tab'
+import Tabs from '@mui/material/Tabs'
+import Typography from '@mui/material/Typography'
+import { onAuthStateChanged } from 'firebase/auth'
+import { collection, getDocs, query, where } from 'firebase/firestore'
+
+import { auth, db } from '@/firebase/config'
+import { contentContainerSx, contentPageSx } from '@/styles/page'
+import type { ArtworkStatus } from '@/types/artwork'
+
+interface UserArtwork {
+  artworkId: string
+  title: string
+  status: ArtworkStatus
+  createdAt: string
+  category: string
+  thumbnailContentId?: string
+  rejectionReason?: string
+}
+
+function ArtworkManagementPage() {
+  const navigate = useNavigate()
+  const [artworks, setArtworks] = useState<UserArtwork[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState('')
+  const [selectedTab, setSelectedTab] = useState<ArtworkStatus>('pending')
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (!user) {
+        setIsAuthenticated(false)
+        navigate('/login')
+        return
+      }
+
+      setIsAuthenticated(true)
+      setIsLoading(true)
+      setErrorMessage('')
+
+      try {
+        const q = query(
+          collection(db, 'artworks'),
+          where('ownerUid', '==', user.uid)
+        )
+        const snapshot = await getDocs(q)
+        const loadedArtworks: UserArtwork[] = snapshot.docs
+          .map((doc) => ({
+            artworkId: doc.data().artworkId,
+            title: doc.data().title,
+            status: doc.data().status,
+            createdAt: doc.data().createdAt,
+            category: doc.data().category,
+            thumbnailContentId: doc.data().thumbnailContentId,
+            rejectionReason: doc.data().rejectionReason,
+          }))
+          .sort(
+            (a, b) =>
+              new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          )
+
+        setArtworks(loadedArtworks)
+      } catch (error) {
+        const errorMsg =
+          error instanceof Error ? error.message : 'Failed to load artworks.'
+        console.error('Firestore error:', error)
+
+        // Handle permission errors more gracefully
+        if (
+          errorMsg.includes('permission') ||
+          errorMsg.includes('Permission')
+        ) {
+          setErrorMessage(
+            'Firestore permission issue. Please check your Firebase security rules.'
+          )
+        } else {
+          setErrorMessage(errorMsg)
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    })
+
+    return unsubscribe
+  }, [navigate])
+
+  const filteredArtworks = artworks.filter((art) => art.status === selectedTab)
+
+  const getStatusColor = (status: ArtworkStatus) => {
+    switch (status) {
+      case 'pending':
+        return 'warning'
+      case 'approved':
+        return 'success'
+      case 'rejected':
+        return 'error'
+      default:
+        return 'default'
+    }
+  }
+
+  const getStatusLabel = (status: ArtworkStatus) => {
+    switch (status) {
+      case 'pending':
+        return 'Pending review'
+      case 'approved':
+        return 'Approved'
+      case 'rejected':
+        return 'Rejected'
+      default:
+        return status
+    }
+  }
+
+  return (
+    <Box component="main" sx={contentPageSx}>
+      <Stack spacing={4} sx={contentContainerSx}>
+        <Typography variant="h3">My Artwork Management</Typography>
+        <Typography color="text.secondary">
+          Track the status of your submitted artworks and manage them here.
+        </Typography>
+
+        {errorMessage && (
+          <Alert severity="error">
+            {errorMessage}
+            <Button
+              size="small"
+              onClick={() => {
+                setErrorMessage('')
+                window.location.reload()
+              }}
+            >
+              Retry
+            </Button>
+          </Alert>
+        )}
+
+        {isAuthenticated && (
+          <>
+            <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+              <Tabs
+                value={selectedTab}
+                onChange={(_, newValue) => setSelectedTab(newValue)}
+              >
+                <Tab label="Pending review" value="pending" />
+                <Tab label="Approved" value="approved" />
+                <Tab label="Rejected" value="rejected" />
+              </Tabs>
+            </Box>
+
+            {isLoading ? (
+              <Typography color="text.secondary">Loading...</Typography>
+            ) : filteredArtworks.length === 0 ? (
+              <Box
+                sx={{
+                  py: 4,
+                  textAlign: 'center',
+                  backgroundColor: '#f5f5f5',
+                  borderRadius: 1,
+                }}
+              >
+                <Typography color="text.secondary" gutterBottom>
+                  {selectedTab === 'pending' &&
+                    'There are no artworks pending review.'}
+                  {selectedTab === 'approved' &&
+                    'There are no approved artworks.'}
+                  {selectedTab === 'rejected' &&
+                    'There are no rejected artworks.'}
+                </Typography>
+                <Button
+                  variant="outlined"
+                  onClick={() => navigate('/submit')}
+                  sx={{ mt: 2 }}
+                >
+                  Submit Artwork
+                </Button>
+              </Box>
+            ) : (
+              <Stack spacing={2}>
+                {filteredArtworks.map((artwork) => (
+                  <Paper
+                    key={artwork.artworkId}
+                    sx={{
+                      p: 3,
+                      cursor: 'pointer',
+                      transition: 'all 0.2s',
+                      '&:hover': {
+                        boxShadow: 3,
+                        transform: 'translateY(-2px)',
+                      },
+                    }}
+                    onClick={() => navigate(`/artworks/${artwork.artworkId}`)}
+                  >
+                    <Stack spacing={2}>
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'flex-start',
+                        }}
+                      >
+                        <Box sx={{ flex: 1 }}>
+                          <Typography variant="h6" gutterBottom>
+                            {artwork.title}
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            Category: {artwork.category}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            Submitted on:{' '}
+                            {new Date(artwork.createdAt).toLocaleDateString(
+                              'en-US'
+                            )}
+                          </Typography>
+                        </Box>
+                        <Chip
+                          label={getStatusLabel(artwork.status)}
+                          color={getStatusColor(artwork.status)}
+                          variant="outlined"
+                        />
+                      </Box>
+
+                      {artwork.status === 'rejected' &&
+                        artwork.rejectionReason && (
+                          <Alert severity="error">
+                            <Typography
+                              variant="body2"
+                              sx={{ fontWeight: 500 }}
+                            >
+                              Rejection reason:
+                            </Typography>
+                            <Typography variant="body2">
+                              {artwork.rejectionReason}
+                            </Typography>
+                          </Alert>
+                        )}
+
+                      <Box sx={{ display: 'flex', gap: 1, pt: 1 }}>
+                        <Button
+                          variant="outlined"
+                          size="small"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            navigate(`/artworks/${artwork.artworkId}`)
+                          }}
+                        >
+                          View details
+                        </Button>
+                        {artwork.status === 'rejected' && (
+                          <Button
+                            variant="contained"
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              navigate('/submit')
+                            }}
+                          >
+                            Resubmit
+                          </Button>
+                        )}
+                      </Box>
+                    </Stack>
+                  </Paper>
+                ))}
+              </Stack>
+            )}
+
+            <Divider sx={{ my: 2 }} />
+
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Button variant="outlined" onClick={() => navigate('/gallery')}>
+                Back to gallery
+              </Button>
+              <Button variant="contained" onClick={() => navigate('/submit')}>
+                Submit new artwork
+              </Button>
+            </Box>
+          </>
+        )}
+      </Stack>
+    </Box>
+  )
+}
+
+export default ArtworkManagementPage

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -168,14 +168,16 @@ export default function ProfilePage() {
             {isSubmitting ? 'Saving...' : 'Save changes'}
           </Button>
 
-          <Button
-            fullWidth
-            onClick={() => navigate('/artwork-management')}
-            type="button"
-            variant="white"
-          >
-            My artwork management
-          </Button>
+          {profileRole === 'student' ? (
+            <Button
+              fullWidth
+              onClick={() => navigate('/artwork-management')}
+              type="button"
+              variant="white"
+            >
+              My artwork management
+            </Button>
+          ) : null}
         </Stack>
       </Stack>
     </Box>

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -18,15 +18,12 @@ import { updateCurrentUserProfile } from '@/firebase/auth'
 import { auth, db } from '@/firebase/config'
 import { centeredPageSx, formFieldSx, formPageSx } from '@/styles/page'
 
+import { profileImageButtonSx, selectedProfileImageButtonSx } from './styles'
 import {
-  profileImageButtonSx,
-  selectedProfileImageButtonSx,
-} from './styles'
-import {
-  getProfileErrorMessage,
-  getProfileImageState,
   type ProfileImageOption,
   type ProfileRole,
+  getProfileErrorMessage,
+  getProfileImageState,
 } from './utils'
 
 export default function ProfilePage() {
@@ -166,9 +163,20 @@ export default function ProfilePage() {
           value={name}
         />
 
-        <Button disabled={isSubmitting} fullWidth type="submit">
-          {isSubmitting ? 'Saving...' : 'Save changes'}
-        </Button>
+        <Stack spacing={1.5}>
+          <Button disabled={isSubmitting} fullWidth type="submit">
+            {isSubmitting ? 'Saving...' : 'Save changes'}
+          </Button>
+
+          <Button
+            fullWidth
+            onClick={() => navigate('/artwork-management')}
+            type="button"
+            variant="white"
+          >
+            My artwork management
+          </Button>
+        </Stack>
       </Stack>
     </Box>
   )

--- a/src/pages/SubmitArtworkPage/index.tsx
+++ b/src/pages/SubmitArtworkPage/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { ChangeEvent, FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -18,7 +18,8 @@ import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { doc, setDoc } from 'firebase/firestore'
+import { onAuthStateChanged } from 'firebase/auth'
+import { doc, getDoc, setDoc } from 'firebase/firestore'
 
 import { auth, db } from '@/firebase/config'
 import { requestFinalizeUpload, uploadFileDirectly } from '@/utils/protection'
@@ -39,6 +40,30 @@ function SubmitArtworkPage() {
   const [thumbnailIndex, setThumbnailIndex] = useState(0)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Check if user is a student
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (!user) {
+        navigate('/login')
+        return
+      }
+
+      try {
+        const userDoc = await getDoc(doc(db, 'users', user.uid))
+        const role = userDoc.data()?.role
+
+        if (role !== 'student') {
+          navigate('/login')
+        }
+      } catch (error) {
+        console.error('Failed to check user role:', error)
+        navigate('/login')
+      }
+    })
+
+    return unsubscribe
+  }, [navigate])
 
   const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const selected = event.target.files ? Array.from(event.target.files) : []

--- a/src/pages/SubmitArtworkPage/index.tsx
+++ b/src/pages/SubmitArtworkPage/index.tsx
@@ -3,69 +3,210 @@ import type { ChangeEvent, FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import Alert from '@mui/material/Alert'
+import Avatar from '@mui/material/Avatar'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import FormControl from '@mui/material/FormControl'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import FormHelperText from '@mui/material/FormHelperText'
+import InputLabel from '@mui/material/InputLabel'
+import MenuItem from '@mui/material/MenuItem'
+import Select from '@mui/material/Select'
+import type { SelectChangeEvent } from '@mui/material/Select'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
+import { doc, setDoc } from 'firebase/firestore'
 
-import { auth } from '@/firebase/config'
+import { auth, db } from '@/firebase/config'
 import { requestFinalizeUpload, uploadFileDirectly } from '@/utils/protection'
 
 function SubmitArtworkPage() {
   const navigate = useNavigate()
   const [title, setTitle] = useState('')
-  const [file, setFile] = useState<File | null>(null)
+  const [files, setFiles] = useState<File[]>([])
+  const [relatedVideo, setRelatedVideo] = useState('')
+  const [category, setCategory] = useState('')
+  const [customCategory, setCustomCategory] = useState('')
+  const [description, setDescription] = useState('')
+  const [creationProcess, setCreationProcess] = useState('')
+  const [productionStart, setProductionStart] = useState('')
+  const [productionEnd, setProductionEnd] = useState('')
+  const [availableForSale, setAvailableForSale] = useState(false)
+  const [termsAgreed, setTermsAgreed] = useState(false)
+  const [thumbnailIndex, setThumbnailIndex] = useState(0)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const selected = event.target.files?.[0] ?? null
-    setFile(selected)
+    const selected = event.target.files ? Array.from(event.target.files) : []
+    setFiles((prev) => [...prev, ...selected])
+  }
+
+  const handleRemoveImage = (idx: number) => {
+    const newFiles = files.filter((_, i) => i !== idx)
+    setFiles(newFiles)
+    if (thumbnailIndex >= newFiles.length && thumbnailIndex > 0) {
+      setThumbnailIndex(thumbnailIndex - 1)
+    }
+  }
+
+  const handleMoveImage = (idx: number, direction: 'up' | 'down') => {
+    const newFiles = [...files]
+    const targetIdx = direction === 'up' ? idx - 1 : idx + 1
+    if (targetIdx >= 0 && targetIdx < newFiles.length) {
+      ;[newFiles[idx], newFiles[targetIdx]] = [
+        newFiles[targetIdx],
+        newFiles[idx],
+      ]
+      setFiles(newFiles)
+      if (thumbnailIndex === idx) {
+        setThumbnailIndex(targetIdx)
+      } else if (thumbnailIndex === targetIdx) {
+        setThumbnailIndex(idx)
+      }
+    }
+  }
+
+  const handleSetThumbnail = (idx: number) => {
+    setThumbnailIndex(idx)
+  }
+
+  const resetForm = () => {
+    setTitle('')
+    setFiles([])
+    setThumbnailIndex(0)
+    setRelatedVideo('')
+    setCategory('')
+    setCustomCategory('')
+    setDescription('')
+    setCreationProcess('')
+    setProductionStart('')
+    setProductionEnd('')
+    setAvailableForSale(false)
+    setTermsAgreed(false)
+    setErrorMessage(null)
   }
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
-    if (!title.trim() || !file) {
-      setErrorMessage('Title and image file are required.')
+    // Clear previous error message
+    setErrorMessage(null)
+
+    if (!title.trim()) {
+      setErrorMessage('Artwork title is required.')
+      return
+    }
+
+    if (files.length === 0) {
+      setErrorMessage('At least one artwork image is required.')
+      return
+    }
+
+    if (!category) {
+      setErrorMessage('Please select a category.')
+      return
+    }
+
+    if (category === 'Other' && !customCategory.trim()) {
+      setErrorMessage('Please specify your custom category.')
+      return
+    }
+
+    if (!termsAgreed) {
+      setErrorMessage('You must agree to the terms and copyright agreement.')
       return
     }
 
     setErrorMessage(null)
     setIsSubmitting(true)
 
+    // Prevent double-submission
+    if (isSubmitting) {
+      setIsSubmitting(false)
+      return
+    }
+
     const artworkId = crypto.randomUUID()
-    const contentId = crypto.randomUUID()
     try {
       const idToken = await auth.currentUser?.getIdToken()
       if (!idToken) {
         throw new Error('You must be signed in to submit artwork.')
       }
 
-      const { storage } = await uploadFileDirectly({
-        file,
-        artworkId,
-        contentId,
-        authToken: idToken,
-      })
+      // Upload all images and collect storage metadata
+      const images: Array<{
+        contentId: string
+        imageName: string
+        storage: unknown
+      }> = []
 
-      await requestFinalizeUpload({
-        payload: {
+      for (let i = 0; i < files.length; i++) {
+        const f = files[i]
+        const contentId = crypto.randomUUID()
+        const resp = await uploadFileDirectly({
+          file: f,
           artworkId,
           contentId,
-          title: title.trim(),
-          imageName: file.name,
-          storage,
-        },
-        authToken: idToken,
-      })
+          authToken: idToken,
+        })
+        images.push({ contentId, imageName: f.name, storage: resp.storage })
 
-      navigate(`/artworks/${artworkId}`)
+        await requestFinalizeUpload({
+          payload: {
+            artworkId,
+            contentId,
+            title: title.trim(),
+            imageName: f.name,
+            storage: resp.storage,
+          },
+          authToken: idToken,
+        })
+      }
+
+      const thumbnail = images[thumbnailIndex]
+      const finalCategory =
+        category === 'Other' ? customCategory.trim() : category
+      const artworkDoc = {
+        artworkId,
+        title: title.trim(),
+        images,
+        thumbnailContentId: thumbnail?.contentId ?? null,
+        relatedVideo: relatedVideo.trim() || null,
+        category: finalCategory,
+        description: description.trim() || null,
+        creationProcess: creationProcess.trim() || null,
+        artistName: auth.currentUser?.displayName ?? null,
+        productionStart: productionStart || null,
+        productionEnd: productionEnd || null,
+        availableForSale,
+        termsAgreed: true,
+        ownerUid: auth.currentUser?.uid ?? null,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+      }
+
+      await setDoc(doc(db, 'artworks', artworkId), artworkDoc)
+
+      resetForm()
+      navigate('/artwork-management')
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to submit artwork.'
-      setErrorMessage(message)
+
+      if (message.includes('Different contentId')) {
+        setErrorMessage(
+          'Upload conflict: Please refresh the page and try again with new images.'
+        )
+      } else {
+        setErrorMessage(message)
+      }
+
+      setFiles([])
+      setThumbnailIndex(0)
     } finally {
       setIsSubmitting(false)
     }
@@ -92,15 +233,270 @@ function SubmitArtworkPage() {
               required
               value={title}
             />
-            <Button component="label" variant="outlined">
-              {file ? `Selected: ${file.name}` : 'Select image file'}
-              <input
-                accept="image/*"
-                hidden
-                onChange={onFileChange}
-                type="file"
+
+            <FormControl required error={files.length === 0} fullWidth>
+              <Typography sx={{ mb: 1 }}>Artwork images</Typography>
+              <Button component="label" variant="outlined" sx={{ py: 2 }}>
+                {files.length > 0
+                  ? `Add more: ${files.length} file(s) selected`
+                  : 'Select image files'}
+                <input
+                  accept="image/*"
+                  hidden
+                  multiple
+                  onChange={onFileChange}
+                  type="file"
+                />
+              </Button>
+              <FormHelperText>
+                Click to add more images. Protection runs for every image.
+              </FormHelperText>
+
+              {files.length > 0 && (
+                <Box
+                  sx={{
+                    mt: 2,
+                    border: '1px solid #ddd',
+                    p: 2,
+                    borderRadius: 1,
+                  }}
+                >
+                  <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                    Images ({files.length})
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ mb: 2, display: 'block' }}
+                  >
+                    Select one image as the thumbnail for gallery display
+                  </Typography>
+                  <Stack spacing={2}>
+                    {files.map((f, idx) => (
+                      <Box
+                        key={`${f.name}-${idx}`}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 2,
+                          p: 1.5,
+                          bgcolor:
+                            thumbnailIndex === idx
+                              ? 'action.hover'
+                              : 'transparent',
+                          borderRadius: 1,
+                          border:
+                            thumbnailIndex === idx
+                              ? '2px solid'
+                              : '1px solid #ddd',
+                          borderColor:
+                            thumbnailIndex === idx ? 'primary.main' : undefined,
+                        }}
+                      >
+                        <Avatar
+                          variant="rounded"
+                          src={URL.createObjectURL(f)}
+                          sx={{
+                            width: 60,
+                            height: 60,
+                            flexShrink: 0,
+                          }}
+                        />
+                        <Box sx={{ flex: 1 }}>
+                          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                            {f.name}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {(f.size / 1024 / 1024).toFixed(2)} MB
+                          </Typography>
+                        </Box>
+
+                        <Stack direction="row" spacing={0.5}>
+                          <Tooltip title="This image will be displayed as gallery thumbnail">
+                            <Button
+                              variant={
+                                thumbnailIndex === idx
+                                  ? 'contained'
+                                  : 'outlined'
+                              }
+                              size="small"
+                              onClick={() => handleSetThumbnail(idx)}
+                              sx={{
+                                minWidth: 'auto',
+                                px: 1.5,
+                              }}
+                            >
+                              {thumbnailIndex === idx ? '✓ Thumbnail' : 'Set'}
+                            </Button>
+                          </Tooltip>
+
+                          <Tooltip title="Move up">
+                            <Button
+                              variant="text"
+                              size="small"
+                              onClick={() => handleMoveImage(idx, 'up')}
+                              disabled={idx === 0}
+                              sx={{ minWidth: 32 }}
+                            >
+                              ↑
+                            </Button>
+                          </Tooltip>
+
+                          <Tooltip title="Move down">
+                            <Button
+                              variant="text"
+                              size="small"
+                              onClick={() => handleMoveImage(idx, 'down')}
+                              disabled={idx === files.length - 1}
+                              sx={{ minWidth: 32 }}
+                            >
+                              ↓
+                            </Button>
+                          </Tooltip>
+
+                          <Tooltip title="Delete image">
+                            <Button
+                              variant="text"
+                              size="small"
+                              onClick={() => handleRemoveImage(idx)}
+                              sx={{ minWidth: 32, color: 'error.main' }}
+                            >
+                              ✕
+                            </Button>
+                          </Tooltip>
+                        </Stack>
+                      </Box>
+                    ))}
+                  </Stack>
+                </Box>
+              )}
+            </FormControl>
+
+            <TextField
+              fullWidth
+              label="Related video (URL)"
+              onChange={(e) => setRelatedVideo(e.target.value)}
+              value={relatedVideo}
+            />
+
+            <FormControl fullWidth required>
+              <InputLabel id="category-label">Category</InputLabel>
+              <Select
+                labelId="category-label"
+                label="Category"
+                value={category}
+                onChange={(e: SelectChangeEvent) => {
+                  setCategory(e.target.value as string)
+                  if (e.target.value !== 'Other') {
+                    setCustomCategory('')
+                  }
+                }}
+              >
+                <MenuItem value="Architecture">Architecture</MenuItem>
+                <MenuItem value="Fine Art">Fine Art</MenuItem>
+                <MenuItem value="Sculpture">Sculpture</MenuItem>
+                <MenuItem value="Design">Design</MenuItem>
+                <MenuItem value="Media Art">Media Art</MenuItem>
+                <MenuItem value="Photography">Photography</MenuItem>
+                <MenuItem value="Illustration">Illustration</MenuItem>
+                <MenuItem value="Animation">Animation</MenuItem>
+                <MenuItem value="Fashion">Fashion</MenuItem>
+                <MenuItem value="Installation">Installation</MenuItem>
+                <MenuItem value="Video Art">Video Art</MenuItem>
+                <MenuItem value="Crafts">Crafts</MenuItem>
+                <MenuItem value="Digital Art">Digital Art</MenuItem>
+                <MenuItem value="Other">Other (specify below)</MenuItem>
+              </Select>
+            </FormControl>
+
+            {category === 'Other' && (
+              <TextField
+                fullWidth
+                label="Specify your category"
+                placeholder="e.g., Textile Art, Ceramics, Jewelry..."
+                onChange={(e) => setCustomCategory(e.target.value)}
+                value={customCategory}
+                required
               />
-            </Button>
+            )}
+
+            <TextField
+              fullWidth
+              label="Artwork description"
+              multiline
+              minRows={3}
+              onChange={(e) => setDescription(e.target.value)}
+              value={description}
+            />
+
+            <TextField
+              fullWidth
+              label="Creation process"
+              multiline
+              minRows={2}
+              onChange={(e) => setCreationProcess(e.target.value)}
+              value={creationProcess}
+            />
+
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+              <Box sx={{ flex: '1 1 240px' }}>
+                <TextField
+                  fullWidth
+                  label="Production start"
+                  type="date"
+                  InputLabelProps={{ shrink: true }}
+                  value={productionStart}
+                  onChange={(e) => setProductionStart(e.target.value)}
+                />
+              </Box>
+              <Box sx={{ flex: '1 1 240px' }}>
+                <TextField
+                  fullWidth
+                  label="Production end"
+                  type="date"
+                  InputLabelProps={{ shrink: true }}
+                  value={productionEnd}
+                  onChange={(e) => setProductionEnd(e.target.value)}
+                />
+              </Box>
+            </Box>
+
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={availableForSale}
+                  onChange={(e) => setAvailableForSale(e.target.checked)}
+                />
+              }
+              label="Available for sale"
+            />
+
+            <Box>
+              <Typography variant="subtitle2">Copyright & Terms</Typography>
+              <Typography color="text.secondary" sx={{ fontSize: 13 }}>
+                - Copyright remains with the artist.
+              </Typography>
+              <Typography color="text.secondary" sx={{ fontSize: 13 }}>
+                - By submitting, you grant the platform a non-exclusive license
+                to display and promote your work.
+              </Typography>
+              <Typography color="text.secondary" sx={{ fontSize: 13 }}>
+                - We provide protection against unauthorized reproduction by
+                generating image protection metadata on submission.
+              </Typography>
+            </Box>
+
+            <FormControl required error={!termsAgreed}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={termsAgreed}
+                    onChange={(e) => setTermsAgreed(e.target.checked)}
+                  />
+                }
+                label="I agree to the Terms of Service & Copyright Agreement"
+              />
+            </FormControl>
 
             {errorMessage ? (
               <Alert severity="error">{errorMessage}</Alert>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter } from 'react-router-dom'
 import Layout from '@/layouts'
 import AdminPage from '@/pages/AdminPage'
 import ArtworkDetailPage from '@/pages/ArtworkDetailPage'
+import ArtworkManagementPage from '@/pages/ArtworkManagementPage'
 import GalleryPage from '@/pages/GalleryPage'
 import HomePage from '@/pages/HomePage'
 import LoginPage from '@/pages/LoginPage'
@@ -22,6 +23,7 @@ export const router = createBrowserRouter([
       { path: 'login', element: <LoginPage /> },
       { path: 'signup', element: <SignupPage /> },
       { path: 'submit', element: <SubmitArtworkPage /> },
+      { path: 'artwork-management', element: <ArtworkManagementPage /> },
       { path: 'admin', element: <AdminPage /> },
       { path: 'profile', element: <ProfilePage /> },
       { path: '*', element: <NotFoundPage /> },

--- a/src/types/blockchain.ts
+++ b/src/types/blockchain.ts
@@ -19,6 +19,7 @@ export interface S3ObjectReference {
 
 export interface ProtectedArtworkRecord {
   id: string
+  artworkId?: string
   title: string
   imageName: string
   contentId?: string
@@ -26,6 +27,19 @@ export interface ProtectedArtworkRecord {
   createdAt: string
   updatedAt?: string
   protection: BlockchainProtection
+}
+
+export interface PendingArtworkGroup {
+  artworkId: string
+  title: string
+  ownerUid?: string
+  createdAt: string
+  updatedAt?: string
+  images: Array<{
+    contentId: string
+    imageName: string
+    status: BlockchainProtectionStatus
+  }>
 }
 
 export interface BlockchainProtection {

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -4,6 +4,15 @@ export type ArtworkCategoryName =
   | 'Sculpture'
   | 'Design'
   | 'Media Art'
+  | 'Photography'
+  | 'Illustration'
+  | 'Animation'
+  | 'Fashion'
+  | 'Installation'
+  | 'Video Art'
+  | 'Crafts'
+  | 'Digital Art'
+  | 'Other'
 
 export interface Category {
   id: string

--- a/src/utils/protection.ts
+++ b/src/utils/protection.ts
@@ -1,6 +1,7 @@
 import type {
   FinalizeUploadRequest,
   FinalizeUploadResponse,
+  PendingArtworkGroup,
   PresignedUploadRequest,
   PresignedUploadResponse,
   ProtectedArtworkRecord,
@@ -134,7 +135,8 @@ export async function requestFinalizeUpload(options: {
 }
 
 export async function requestApproveArtworkRegistration(options: {
-  artworkId: string
+  artworkId?: string
+  contentId?: string
   authToken: string
 }): Promise<{
   artworkId: string
@@ -148,6 +150,10 @@ export async function requestApproveArtworkRegistration(options: {
     throw new Error(
       'Missing VITE_APPROVE_ARTWORK_ENDPOINT. Set your admin approval API endpoint in environment variables.'
     )
+  }
+
+  if (!artworkId) {
+    throw new Error('artworkId is required for approval.')
   }
 
   const response = await fetch(endpoint, {
@@ -201,7 +207,7 @@ export async function requestProtectedArtworkStatus(options: {
 }
 
 export async function requestPendingProtectedArtworks(): Promise<
-  ProtectedArtworkRecord[]
+  PendingArtworkGroup[]
 > {
   const endpoint = import.meta.env.VITE_PENDING_ARTWORKS_ENDPOINT
 
@@ -224,7 +230,7 @@ export async function requestPendingProtectedArtworks(): Promise<
   }
 
   const payload = (await response.json()) as {
-    items?: ProtectedArtworkRecord[]
+    items?: PendingArtworkGroup[]
   }
 
   return payload.items ?? []


### PR DESCRIPTION
## Summary
Complete artwork submission system with multi-image support, batch approval workflow, and role-based access control. Students can submit artworks with multiple images, admins approve entire submissions for chain registration, and all images are processed sequentially for stability.

## Changes

### Backend - Cloud Functions
- **Image Grouping**: `listPendingArtworkProtection` - Groups images by artworkId for batch processing
- **Batch Approval**: `approveArtworkRegistration` - Accept artworkId, batch-update all pending images, trigger async registration
- **Sequential Registration**: Changed from parallel (`Promise.all`) to sequential (for loop) processing to avoid resource contention
- **Status Sync**: Added `syncArtworkApprovalStatus` to update artworks collection to 'approved' after all images register
- **Protection Status Query**: `getArtworkProtectionStatus` - Now queries by artworkId to find all related images
- **Finalize Handler**: Fixed document ID from artworkId to contentId for proper protectedArtworks collection storage

### Frontend - React/TypeScript
- **Multi-Image Upload**: `SubmitArtworkPage` - Select multiple images with preview, reorder, set thumbnail
- **Category Expansion**: 14 categories (Architecture, Fine Art, Sculpture, Design, Media Art, Photography, Illustration, Animation, Fashion, Installation, Video Art, Crafts, Digital Art, Other)
- **Metadata Collection**: Title, description, creation process, production dates, video URL, availability for sale, copyright agreement
- **Artwork Management**: New `ArtworkManagementPage` - Students view submission status (pending/approved/rejected) with tabs
- **Admin Interface**: Redesigned `AdminPage` - Display artworks grouped by submission, show nested images, one approval button per artwork
- **Role-Based Access**: 
  * `SubmitArtworkPage` - Redirects non-student users to login
  * `Header` - Shows "Submit work" button only for students
  * `ProfilePage` - Shows "My artwork management" button only for students

### Data & Types
- **New Type**: `PendingArtworkGroup` - Represents artwork with list of images for admin display
- **Category Expansion**: Added 11 new categories to `ArtworkCategoryName` type
- **Routes**: Added `/artwork-management` route for student artwork tracking

### Security
- **Firestore Rules**: Created firestore.rules with proper access control for artworks and protectedArtworks collections
- **User Role Verification**: Check user role before allowing artwork submission

### Navigation
- Added "My artwork management" menu item to Header profile dropdown (students only)
- Added "My artwork management" button to ProfilePage (students only)
- Integrated artwork management into navigation flow

## Why
This implementation achieves the complete artwork protection and registration workflow:

1. **Multi-Image Support**: Students can submit entire art series in one submission
2. **Batch Processing**: Admins approve artwork once; all images register together
3. **Sequential Stability**: Fixed resource contention issues by processing images sequentially instead of in parallel
4. **Student Accountability**: Only students can submit artworks (educational platform requirement)
5. **Transparency**: Students can track their submissions through status tabs
6. **Security**: Firestore rules and role-based access control prevent unauthorized operations

## Testing
- [x] `npm run build`
- [x] manual check completed
- [ ] not tested

## Notes
