### PR TITLE
issue#12 Implement artwork review workflow with status filtering and approval system

### DIFF
--- a/src/pages/AdminPage/index.tsx
+++ b/src/pages/AdminPage/index.tsx
@@ -4,48 +4,128 @@ import { useNavigate } from 'react-router-dom'
 import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
 import Divider from '@mui/material/Divider'
+import FormControl from '@mui/material/FormControl'
+import InputLabel from '@mui/material/InputLabel'
+import MenuItem from '@mui/material/MenuItem'
+import Paper from '@mui/material/Paper'
+import Select from '@mui/material/Select'
 import Stack from '@mui/material/Stack'
+import Tab from '@mui/material/Tab'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableContainer from '@mui/material/TableContainer'
+import TableHead from '@mui/material/TableHead'
+import TablePagination from '@mui/material/TablePagination'
+import TableRow from '@mui/material/TableRow'
+import Tabs from '@mui/material/Tabs'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { onAuthStateChanged } from 'firebase/auth'
-import { doc, getDoc } from 'firebase/firestore'
+import {
+  addDoc,
+  collection,
+  deleteField,
+  doc,
+  getDoc,
+  getDocs,
+  updateDoc,
+} from 'firebase/firestore'
 
 import { auth, db } from '@/firebase/config'
 import { contentContainerSx, contentPageSx } from '@/styles/page'
-import type { PendingArtworkGroup } from '@/types/blockchain'
-import {
-  requestApproveArtworkRegistration,
-  requestPendingProtectedArtworks,
-} from '@/utils/protection'
+import type { ArtworkStatus } from '@/types/artwork'
+import type { NotificationType } from '@/types/notification'
+import { requestApproveArtworkRegistration } from '@/utils/protection'
+
+const ROWS_PER_PAGE = 5
+
+interface AdminArtworkImage {
+  contentId?: string
+  imageName?: string
+}
+
+interface AdminArtwork {
+  artworkId: string
+  title: string
+  ownerUid?: string
+  status: ArtworkStatus
+  category: string
+  createdAt: string
+  updatedAt?: string
+  description?: string
+  creationProcess?: string
+  rejectionReason?: string
+  images: AdminArtworkImage[]
+}
 
 function AdminPage() {
   const navigate = useNavigate()
-  const [pendingArtworks, setPendingArtworks] = useState<PendingArtworkGroup[]>(
-    []
-  )
+  const [artworks, setArtworks] = useState<AdminArtwork[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [selectedStatus, setSelectedStatus] = useState<ArtworkStatus>('pending')
+  const [pageByCategory, setPageByCategory] = useState<Record<string, number>>(
+    {}
+  )
+  const [selectedCategory, setSelectedCategory] = useState<string>('all')
+  const [selectedArtwork, setSelectedArtwork] = useState<AdminArtwork | null>(
+    null
+  )
   const [isApprovingArtworkId, setIsApprovingArtworkId] = useState('')
+  const [isRejectingArtworkId, setIsRejectingArtworkId] = useState('')
+  const [rejectTarget, setRejectTarget] = useState<AdminArtwork | null>(null)
+  const [rejectReasonInput, setRejectReasonInput] = useState('')
+  const [rejectReasonError, setRejectReasonError] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
   const [successMessage, setSuccessMessage] = useState('')
   const [isAdmin, setIsAdmin] = useState(false)
 
-  useEffect(() => {
-    const loadPendingArtworks = async () => {
-      setIsLoading(true)
+  const loadArtworks = async () => {
+    setIsLoading(true)
+    setErrorMessage('')
 
-      try {
-        const artworks = await requestPendingProtectedArtworks()
-        setPendingArtworks(artworks)
-      } catch (error) {
-        setErrorMessage(
-          error instanceof Error ? error.message : 'Failed to load artworks.'
+    try {
+      const snapshot = await getDocs(collection(db, 'artworks'))
+      const loadedArtworks: AdminArtwork[] = snapshot.docs
+        .map((docSnapshot) => {
+          const data = docSnapshot.data()
+          return {
+            artworkId: data.artworkId ?? docSnapshot.id,
+            title: data.title ?? 'Untitled artwork',
+            ownerUid: data.ownerUid,
+            status: (data.status ?? 'pending') as ArtworkStatus,
+            category: data.category ?? 'Uncategorized',
+            createdAt: data.createdAt ?? new Date(0).toISOString(),
+            updatedAt: data.updatedAt,
+            description: data.description,
+            creationProcess: data.creationProcess,
+            rejectionReason: data.rejectionReason,
+            images: Array.isArray(data.images) ? data.images : [],
+          }
+        })
+        .sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
         )
-      } finally {
-        setIsLoading(false)
-      }
-    }
 
-    void loadPendingArtworks()
+      setArtworks(loadedArtworks)
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Failed to load artworks.'
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadArtworks()
   }, [])
 
   useEffect(() => {
@@ -62,10 +142,39 @@ function AdminPage() {
     return unsubscribe
   }, [])
 
-  const handleApprove = async (artworkId: string) => {
+  useEffect(() => {
+    setPageByCategory({})
+  }, [selectedStatus])
+
+  useEffect(() => {
+    setPageByCategory({})
+  }, [selectedCategory])
+
+  const createAdminNotification = async (options: {
+    receiverId?: string
+    type: NotificationType
+    artworkId: string
+    message: string
+  }) => {
+    const { receiverId, type, artworkId, message } = options
+    if (!receiverId) {
+      return
+    }
+
+    await addDoc(collection(db, 'notifications'), {
+      receiverId,
+      type,
+      message,
+      artworkId,
+      createdAt: new Date().toISOString(),
+      isRead: false,
+    })
+  }
+
+  const handleApprove = async (artwork: AdminArtwork) => {
     setErrorMessage('')
     setSuccessMessage('')
-    setIsApprovingArtworkId(artworkId)
+    setIsApprovingArtworkId(artwork.artworkId)
 
     try {
       const currentUser = auth.currentUser
@@ -75,15 +184,25 @@ function AdminPage() {
 
       const idToken = await currentUser.getIdToken()
       await requestApproveArtworkRegistration({
-        artworkId,
+        artworkId: artwork.artworkId,
         authToken: idToken,
       })
 
-      setSuccessMessage(
-        `Artwork "${pendingArtworks.find((a) => a.artworkId === artworkId)?.title}" approved. Chain registration for all ${pendingArtworks.find((a) => a.artworkId === artworkId)?.images.length} images is now running in background.`
-      )
-      const artworks = await requestPendingProtectedArtworks()
-      setPendingArtworks(artworks)
+      await updateDoc(doc(db, 'artworks', artwork.artworkId), {
+        status: 'approved',
+        rejectionReason: deleteField(),
+        updatedAt: new Date().toISOString(),
+      })
+
+      await createAdminNotification({
+        receiverId: artwork.ownerUid,
+        type: 'approval',
+        artworkId: artwork.artworkId,
+        message: `Your artwork "${artwork.title}" has been approved.`,
+      })
+
+      setSuccessMessage(`Artwork "${artwork.title}" approved successfully.`)
+      await loadArtworks()
     } catch (error) {
       setErrorMessage(
         error instanceof Error ? error.message : 'Failed to approve artwork.'
@@ -93,13 +212,103 @@ function AdminPage() {
     }
   }
 
+  const openRejectDialog = (artwork: AdminArtwork) => {
+    setRejectTarget(artwork)
+    setRejectReasonInput('')
+    setRejectReasonError('')
+  }
+
+  const closeRejectDialog = () => {
+    setRejectTarget(null)
+    setRejectReasonInput('')
+    setRejectReasonError('')
+  }
+
+  const handleReject = async () => {
+    if (!rejectTarget) {
+      return
+    }
+
+    const trimmedReason = rejectReasonInput.trim()
+    if (!trimmedReason) {
+      setRejectReasonError('Rejection reason is required.')
+      return
+    }
+
+    setErrorMessage('')
+    setSuccessMessage('')
+    setRejectReasonError('')
+    setIsRejectingArtworkId(rejectTarget.artworkId)
+
+    try {
+      await updateDoc(doc(db, 'artworks', rejectTarget.artworkId), {
+        status: 'rejected',
+        rejectionReason: trimmedReason,
+        updatedAt: new Date().toISOString(),
+      })
+
+      await createAdminNotification({
+        receiverId: rejectTarget.ownerUid,
+        type: 'rejection',
+        artworkId: rejectTarget.artworkId,
+        message: `Your artwork "${rejectTarget.title}" was rejected. Reason: ${trimmedReason}`,
+      })
+
+      setSuccessMessage(`Artwork "${rejectTarget.title}" rejected.`)
+      closeRejectDialog()
+      await loadArtworks()
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Failed to reject artwork.'
+      )
+    } finally {
+      setIsRejectingArtworkId('')
+    }
+  }
+
+  const filteredArtworks = artworks.filter(
+    (artwork) => artwork.status === selectedStatus
+  )
+
+  const groupedArtworks = filteredArtworks.reduce<
+    Record<string, AdminArtwork[]>
+  >((acc, artwork) => {
+    const categoryKey = artwork.category || 'Uncategorized'
+    acc[categoryKey] = [...(acc[categoryKey] ?? []), artwork]
+    return acc
+  }, {})
+
+  const orderedCategories = Object.keys(groupedArtworks).sort((a, b) =>
+    a.localeCompare(b)
+  )
+
+  const categoriesToRender =
+    selectedCategory === 'all'
+      ? orderedCategories
+      : orderedCategories.includes(selectedCategory)
+        ? [selectedCategory]
+        : []
+
+  const getStatusChipColor = (status: ArtworkStatus) => {
+    switch (status) {
+      case 'pending':
+        return 'warning'
+      case 'approved':
+        return 'success'
+      case 'rejected':
+        return 'error'
+      default:
+        return 'default'
+    }
+  }
+
   return (
     <Box component="main" sx={contentPageSx}>
       <Stack spacing={4} sx={contentContainerSx}>
         <Typography variant="h3">Admin Page</Typography>
         <Typography color="text.secondary">
-          Review uploaded artworks and approve them to start the protection
-          pipeline.
+          Review submitted artworks by status and category. You can approve or
+          reject pending submissions with a required rejection reason.
         </Typography>
 
         {!isAdmin ? (
@@ -115,124 +324,340 @@ function AdminPage() {
 
         <Divider />
 
-        {isLoading ? (
-          <Typography>Loading pending artworks...</Typography>
-        ) : null}
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <Tabs
+            value={selectedStatus}
+            onChange={(_, nextValue) =>
+              setSelectedStatus(nextValue as ArtworkStatus)
+            }
+          >
+            <Tab label="Pending" value="pending" />
+            <Tab label="Approved" value="approved" />
+            <Tab label="Rejected" value="rejected" />
+          </Tabs>
+        </Box>
 
-        {!isLoading && pendingArtworks.length === 0 ? (
-          <Alert severity="info">No artworks are waiting for approval.</Alert>
+        {isLoading ? <Typography>Loading artworks...</Typography> : null}
+
+        {!isLoading && filteredArtworks.length === 0 ? (
+          <Alert severity="info">
+            No artworks found for the selected status.
+          </Alert>
         ) : null}
 
         <Stack spacing={2}>
-          {pendingArtworks.map((artwork) => (
-            <Stack
-              key={artwork.artworkId}
-              spacing={1.5}
+          {!isLoading && (
+            <Paper
               sx={{
-                border: '1px solid',
-                borderColor: 'divider',
-                borderRadius: 2,
-                p: 3,
+                px: 2,
+                py: 1,
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
               }}
             >
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'flex-start',
-                }}
-              >
-                <Box sx={{ flex: 1 }}>
-                  <Typography variant="h6" gutterBottom>
-                    {artwork.title || 'Untitled artwork'}
-                  </Typography>
-                  <Typography color="text.secondary" variant="body2">
-                    Submission ID: {artwork.artworkId}
-                  </Typography>
-                  <Typography color="text.secondary" variant="body2">
-                    Owner: {artwork.ownerUid ?? 'Unknown'}
-                  </Typography>
-                </Box>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    backgroundColor: '#e3f2fd',
-                    px: 2,
-                    py: 0.75,
-                    borderRadius: 1,
-                    fontWeight: 500,
-                  }}
-                >
-                  {artwork.images.length} image
-                  {artwork.images.length !== 1 ? 's' : ''}
-                </Typography>
-              </Box>
-
-              <Stack spacing={1}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-                  Images to register:
-                </Typography>
-                {artwork.images.map((image, idx) => (
-                  <Box
-                    key={`${artwork.artworkId}-${idx}`}
-                    sx={{
-                      p: 1.5,
-                      backgroundColor: '#f5f5f5',
-                      borderRadius: 1,
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                    }}
-                  >
-                    <Box>
-                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                        {image.imageName}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {image.contentId}
-                      </Typography>
-                    </Box>
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        backgroundColor:
-                          image.status === 'hashed' ? '#fff3cd' : '#d4edda',
-                        px: 1.5,
-                        py: 0.5,
-                        borderRadius: 1,
-                        fontWeight: 500,
-                      }}
-                    >
-                      {image.status}
-                    </Typography>
-                  </Box>
-                ))}
-              </Stack>
-
-              <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
-                <Button
-                  disabled={
-                    !isAdmin || isApprovingArtworkId === artwork.artworkId
+              <Typography variant="h6">Category</Typography>
+              <FormControl sx={{ minWidth: 260 }} size="small">
+                <InputLabel id="admin-category-select-label">
+                  Category
+                </InputLabel>
+                <Select
+                  labelId="admin-category-select-label"
+                  value={selectedCategory}
+                  label="Category"
+                  onChange={(e) =>
+                    setSelectedCategory(e.target.value as string)
                   }
-                  onClick={() => void handleApprove(artwork.artworkId)}
-                  variant="contained"
-                  sx={{ flex: 1 }}
                 >
-                  {isApprovingArtworkId === artwork.artworkId
-                    ? 'Approving...'
-                    : 'Approve all images'}
-                </Button>
-                <Button
-                  onClick={() => navigate(`/artworks/${artwork.artworkId}`)}
-                  variant="outlined"
-                  sx={{ flex: 1 }}
-                >
-                  View submission
-                </Button>
-              </Stack>
-            </Stack>
-          ))}
+                  <MenuItem value="all">
+                    All ({filteredArtworks.length})
+                  </MenuItem>
+                  {orderedCategories.map((cat) => (
+                    <MenuItem key={cat} value={cat}>
+                      {cat} ({groupedArtworks[cat]?.length ?? 0})
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Paper>
+          )}
+          {!isLoading &&
+            categoriesToRender.map((category) => {
+              const categoryArtworks = groupedArtworks[category]
+              const page = pageByCategory[category] ?? 0
+              const pagedRows = categoryArtworks.slice(
+                page * ROWS_PER_PAGE,
+                page * ROWS_PER_PAGE + ROWS_PER_PAGE
+              )
+
+              return (
+                <Paper key={category} sx={{ overflow: 'hidden' }}>
+                  <Stack
+                    direction="row"
+                    justifyContent="space-between"
+                    alignItems="center"
+                    sx={{ px: 2.5, py: 2 }}
+                  >
+                    <Typography variant="h6">{category}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {categoryArtworks.length} item
+                      {categoryArtworks.length > 1 ? 's' : ''}
+                    </Typography>
+                  </Stack>
+
+                  <TableContainer>
+                    <Table size="small">
+                      <TableHead>
+                        <TableRow>
+                          <TableCell>Title</TableCell>
+                          <TableCell>Owner</TableCell>
+                          <TableCell>Status</TableCell>
+                          <TableCell>Submitted</TableCell>
+                          <TableCell align="right">Actions</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {pagedRows.map((artwork) => (
+                          <TableRow
+                            key={artwork.artworkId}
+                            hover
+                            onClick={() => setSelectedArtwork(artwork)}
+                            sx={{ cursor: 'pointer' }}
+                          >
+                            <TableCell>
+                              <Typography sx={{ fontWeight: 500 }}>
+                                {artwork.title}
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                              >
+                                ID: {artwork.artworkId}
+                              </Typography>
+                            </TableCell>
+                            <TableCell>
+                              {artwork.ownerUid ?? 'Unknown'}
+                            </TableCell>
+                            <TableCell>
+                              <Chip
+                                label={artwork.status}
+                                color={getStatusChipColor(artwork.status)}
+                                size="small"
+                              />
+                            </TableCell>
+                            <TableCell>
+                              {new Date(artwork.createdAt).toLocaleString(
+                                'en-US'
+                              )}
+                            </TableCell>
+                            <TableCell align="right">
+                              <Stack
+                                direction="row"
+                                spacing={1}
+                                justifyContent="flex-end"
+                                onClick={(event) => event.stopPropagation()}
+                              >
+                                <Button
+                                  size="small"
+                                  variant="outlined"
+                                  onClick={() => setSelectedArtwork(artwork)}
+                                >
+                                  Detail
+                                </Button>
+                                <Button
+                                  size="small"
+                                  variant="outlined"
+                                  onClick={() =>
+                                    navigate(`/artworks/${artwork.artworkId}`)
+                                  }
+                                >
+                                  Open page
+                                </Button>
+                                {artwork.status === 'pending' ? (
+                                  <>
+                                    <Button
+                                      size="small"
+                                      variant="contained"
+                                      disabled={
+                                        !isAdmin ||
+                                        isApprovingArtworkId ===
+                                          artwork.artworkId
+                                      }
+                                      onClick={() =>
+                                        void handleApprove(artwork)
+                                      }
+                                    >
+                                      {isApprovingArtworkId ===
+                                      artwork.artworkId
+                                        ? 'Approving...'
+                                        : 'Approve'}
+                                    </Button>
+                                    <Button
+                                      size="small"
+                                      color="error"
+                                      variant="outlined"
+                                      disabled={
+                                        !isAdmin ||
+                                        isRejectingArtworkId ===
+                                          artwork.artworkId
+                                      }
+                                      onClick={() => openRejectDialog(artwork)}
+                                    >
+                                      Reject
+                                    </Button>
+                                  </>
+                                ) : null}
+                              </Stack>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+
+                  <TablePagination
+                    component="div"
+                    count={categoryArtworks.length}
+                    page={Math.min(
+                      page,
+                      Math.max(
+                        Math.ceil(categoryArtworks.length / ROWS_PER_PAGE) - 1,
+                        0
+                      )
+                    )}
+                    onPageChange={(_, nextPage) =>
+                      setPageByCategory((prev) => ({
+                        ...prev,
+                        [category]: nextPage,
+                      }))
+                    }
+                    rowsPerPage={ROWS_PER_PAGE}
+                    rowsPerPageOptions={[ROWS_PER_PAGE]}
+                  />
+                </Paper>
+              )
+            })}
         </Stack>
+
+        <Dialog
+          open={Boolean(selectedArtwork)}
+          onClose={() => setSelectedArtwork(null)}
+          fullWidth
+          maxWidth="md"
+        >
+          <DialogTitle>Artwork detail</DialogTitle>
+          <DialogContent>
+            {selectedArtwork ? (
+              <Stack spacing={2} sx={{ pt: 1 }}>
+                <Typography variant="h6">{selectedArtwork.title}</Typography>
+                <Typography color="text.secondary">
+                  ID: {selectedArtwork.artworkId}
+                </Typography>
+                <Typography color="text.secondary">
+                  Category: {selectedArtwork.category}
+                </Typography>
+                <Typography color="text.secondary">
+                  Owner: {selectedArtwork.ownerUid ?? 'Unknown'}
+                </Typography>
+                <Typography color="text.secondary">
+                  Submitted:{' '}
+                  {new Date(selectedArtwork.createdAt).toLocaleString('en-US')}
+                </Typography>
+                <Typography>
+                  Description: {selectedArtwork.description || 'No description'}
+                </Typography>
+                <Typography>
+                  Creation process:{' '}
+                  {selectedArtwork.creationProcess || 'No creation process'}
+                </Typography>
+                {selectedArtwork.rejectionReason ? (
+                  <Alert severity="error">
+                    Rejection reason: {selectedArtwork.rejectionReason}
+                  </Alert>
+                ) : null}
+
+                <Divider />
+
+                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                  Uploaded images ({selectedArtwork.images.length})
+                </Typography>
+                {selectedArtwork.images.length === 0 ? (
+                  <Typography color="text.secondary">
+                    No image metadata
+                  </Typography>
+                ) : (
+                  <Stack spacing={1}>
+                    {selectedArtwork.images.map((image, index) => (
+                      <Box
+                        key={`${selectedArtwork.artworkId}-${index}`}
+                        sx={{
+                          border: '1px solid',
+                          borderColor: 'divider',
+                          borderRadius: 1,
+                          p: 1.5,
+                        }}
+                      >
+                        <Typography sx={{ fontWeight: 500 }}>
+                          {image.imageName || `Image ${index + 1}`}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          Content ID: {image.contentId ?? 'N/A'}
+                        </Typography>
+                      </Box>
+                    ))}
+                  </Stack>
+                )}
+              </Stack>
+            ) : null}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setSelectedArtwork(null)}>Close</Button>
+          </DialogActions>
+        </Dialog>
+
+        <Dialog
+          open={Boolean(rejectTarget)}
+          onClose={closeRejectDialog}
+          fullWidth
+          maxWidth="sm"
+        >
+          <DialogTitle>Reject artwork</DialogTitle>
+          <DialogContent>
+            <Stack spacing={2} sx={{ pt: 1 }}>
+              <Typography color="text.secondary">
+                Artwork: {rejectTarget?.title}
+              </Typography>
+              <TextField
+                label="Rejection reason"
+                value={rejectReasonInput}
+                onChange={(event) => setRejectReasonInput(event.target.value)}
+                error={Boolean(rejectReasonError)}
+                helperText={
+                  rejectReasonError || 'This reason will be sent to the artist.'
+                }
+                required
+                multiline
+                minRows={3}
+              />
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={closeRejectDialog}
+              disabled={Boolean(isRejectingArtworkId)}
+            >
+              Cancel
+            </Button>
+            <Button
+              color="error"
+              variant="contained"
+              onClick={() => void handleReject()}
+              disabled={Boolean(isRejectingArtworkId)}
+            >
+              {isRejectingArtworkId ? 'Rejecting...' : 'Reject'}
+            </Button>
+          </DialogActions>
+        </Dialog>
       </Stack>
     </Box>
   )

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -10,6 +10,7 @@ import Snackbar from '@mui/material/Snackbar'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
+import { doc, getDoc } from 'firebase/firestore'
 
 import Button from '@/components/Button'
 import {
@@ -18,6 +19,7 @@ import {
   loginWithEmail,
   resendVerificationEmail,
 } from '@/firebase/auth'
+import { db } from '@/firebase/config'
 import { centeredPageSx, formFieldSx, formPageSx } from '@/styles/page'
 
 import { getLoginErrorMessage } from './utils'
@@ -44,12 +46,24 @@ function LoginPage() {
     setIsSubmitting(true)
 
     try {
-      await loginWithEmail({
+      const user = await loginWithEmail({
         email: email.trim(),
         password,
       })
 
-      navigate('/gallery')
+      try {
+        const snapshot = await getDoc(doc(db, 'users', user.uid))
+        const role = snapshot.data()?.role
+        console.log('[LoginPage] User role:', role)
+        if (role === 'admin') {
+          navigate('/admin')
+        } else {
+          navigate('/gallery')
+        }
+      } catch (error) {
+        console.error('[LoginPage] Failed to fetch user role:', error)
+        navigate('/gallery')
+      }
     } catch (error) {
       setErrorMessage(getLoginErrorMessage(error))
       setShowResendVerification(
@@ -86,8 +100,15 @@ function LoginPage() {
     setIsGoogleSubmitting(true)
 
     try {
-      await loginVisitorWithGoogle()
-      navigate('/gallery')
+      const user = await loginVisitorWithGoogle()
+      const snapshot = await getDoc(doc(db, 'users', user.uid))
+      const role = snapshot.data()?.role
+      console.log('[GoogleLogin] User role:', role)
+      if (role === 'admin') {
+        navigate('/admin')
+      } else {
+        navigate('/gallery')
+      }
     } catch (error) {
       setErrorMessage(getLoginErrorMessage(error))
     } finally {
@@ -98,7 +119,12 @@ function LoginPage() {
   return (
     <>
       <Box component="main" sx={centeredPageSx}>
-        <Stack component="form" onSubmit={handleSubmit} spacing={3} sx={formPageSx}>
+        <Stack
+          component="form"
+          onSubmit={handleSubmit}
+          spacing={3}
+          sx={formPageSx}
+        >
           <Box>
             <Typography variant="h3">Log in</Typography>
             <Typography color="text.secondary" sx={{ mt: 1 }} variant="body1">


### PR DESCRIPTION
## Summary
Implemented admin review workflow enabling admins to manage submitted artworks through approval/rejection actions. Admins are automatically redirected to the admin page upon login, where they can filter artworks by status (Pending/Approved/Rejected) and category, view detailed information, and manage submissions with required rejection reasons.

## Changes

### Admin Page
- Status Tabs: Filter artworks by Pending/Approved/Rejected status
- Category Dropdown: Select categories with item counts (All + individual categories)
- Table with Pagination: Display artworks in MUI Table grouped by category, 5 items per page
- Detail Modal: View full artwork information (title, description, creation process, rejection reason, uploaded images, etc.)
- Approve Action: Change artwork status to 'approved' and update Firestore document
- Reject Action: Required dialog for rejection reason input, then update status to 'rejected'
- Notification Storage: Save approval/rejection notifications to Firestore with artwork ID and message

### Login Page
- Fetch user role from Firestore document after login
- Redirect to /admin if role === 'admin', otherwise /gallery
- Apply logic to both email and Google login flows
- Add console logging for debugging role lookup

## Why
This feature enables efficient artwork review and curation by admins. Immediate feedback through notifications improves artist experience and ensures exhibition quality control through the approval workflow.

## Testing
- [x] `npm run build`
- [x] manual check completed
- [ ] not tested

## Notes
<img width="1234" height="814" alt="image" src="https://github.com/user-attachments/assets/ef805385-b8a4-4bdc-8261-5f222916075d" />

<img width="1220" height="826" alt="image" src="https://github.com/user-attachments/assets/e3cb9912-9e6e-4823-8953-a49d4aabe2c6" />


<img width="1238" height="674" alt="image" src="https://github.com/user-attachments/assets/548e7126-ca37-4046-8094-d0bef835c133" />
