### PR TITLE
issue#14 Implement artwork detail page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^7.3.10",
         "@mui/lab": "^7.0.1-beta.23",
         "@mui/material": "^7.3.9",
         "firebase": "^12.10.0",
@@ -1813,13 +1814,39 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.9.tgz",
-      "integrity": "sha512-MOkOCTfbMJwLshlBCKJ59V2F/uaLYfmKnN76kksj6jlGUVdI25A9Hzs08m+zjBRdLv+sK7Rqdsefe8X7h/6PCw==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.10.tgz",
+      "integrity": "sha512-vrOpWRmPJSuwLo23J62wggEm/jvGdzqctej+UOCtgDUz6nZJQuj3ByPccVyaa7eQmwAzUwKN56FQPMKkqbj1GA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.10.tgz",
+      "integrity": "sha512-Au0ma4NSKGKNiimukj8UT/W1x2Qx6Qwn2RvFGykiSqVLYBNlIOPbjnIMvrwLGLu89EEpTVdu/ys/OduZR+tWqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.3.10",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/lab": {
@@ -1867,17 +1894,17 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.9.tgz",
-      "integrity": "sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.10.tgz",
+      "integrity": "sha512-cHvGOk2ZEfbQt3LnGe0ZKd/ETs9gsUpkW66DCO+GSjMZhpdKU4XsuIr7zJ/B/2XaN8ihxuzHfYAR4zPtCN4RYg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
-        "@mui/core-downloads-tracker": "^7.3.9",
-        "@mui/system": "^7.3.9",
+        "@mui/core-downloads-tracker": "^7.3.10",
+        "@mui/system": "^7.3.10",
         "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
+        "@mui/utils": "^7.3.10",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -1896,7 +1923,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.9",
+        "@mui/material-pigment-css": "^7.3.10",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1917,13 +1944,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.9.tgz",
-      "integrity": "sha512-ErIyRQvsiQEq7Yvcvfw9UDHngaqjMy9P3JDPnRAaKG5qhpl2C4tX/W1S4zJvpu+feihmZJStjIyvnv6KDbIrlw==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.10.tgz",
+      "integrity": "sha512-j3EZN+zOctxUISvJSmsEPo5o2F8zse4l5vRkBY+ps6UtnL6J7o14kUaI4w7gwo73id9e3cDNMVQK/9BVaMHVBw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
-        "@mui/utils": "^7.3.9",
+        "@mui/utils": "^7.3.10",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1944,9 +1971,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.9.tgz",
-      "integrity": "sha512-JqujWt5bX4okjUPGpVof/7pvgClqh7HvIbsIBIOOlCh2u3wG/Bwp4+E1bc1dXSwkrkp9WUAoNdI5HEC+5HKvMw==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
+      "integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
@@ -1978,16 +2005,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.9.tgz",
-      "integrity": "sha512-aL1q9am8XpRrSabv9qWf5RHhJICJql34wnrc1nz0MuOglPRYF/liN+c8VqZdTvUn9qg+ZjRVbKf4sJVFfIDtmg==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.10.tgz",
+      "integrity": "sha512-/sfPpdpJaQn7BSF+avjIdHSYmxHp0UOBYNxSG9QGKfMOD6sLANCpRPCnanq1Pe0lFf0NHkO2iUk0TNzdWC1USQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
-        "@mui/private-theming": "^7.3.9",
-        "@mui/styled-engine": "^7.3.9",
+        "@mui/private-theming": "^7.3.10",
+        "@mui/styled-engine": "^7.3.10",
         "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
+        "@mui/utils": "^7.3.10",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
@@ -2035,9 +2062,9 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.9.tgz",
-      "integrity": "sha512-U6SdZaGbfb65fqTsH3V5oJdFj9uYwyLE2WVuNvmbggTSDBb8QHrFsqY8BN3taK9t3yJ8/BPHD/kNvLNyjwM7Yw==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.10.tgz",
+      "integrity": "sha512-7y2eIfy0h7JPz+Yy4pS+wgV68d46PuuxDqKBN4Q8VlPQSsCAGwroMCV6xWyc7g9dvEp8ZNFsknc59GHWO+r6Ow==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.3.10",
     "@mui/lab": "^7.0.1-beta.23",
     "@mui/material": "^7.3.9",
     "firebase": "^12.10.0",
@@ -24,9 +25,9 @@
     "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
-    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.2.1",
+    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/pages/ArtistProfilePage/index.tsx
+++ b/src/pages/ArtistProfilePage/index.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useState } from 'react'
+import { Link as RouterLink, useParams } from 'react-router-dom'
+
+import Alert from '@mui/material/Alert'
+import Avatar from '@mui/material/Avatar'
+import Box from '@mui/material/Box'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+} from 'firebase/firestore'
+
+import ArtworkCard from '@/components/Artwork'
+import { DEFAULT_PROFILE_IMAGE_URL } from '@/constants/profileIcons'
+import { db } from '@/firebase/config'
+import { contentContainerSx, contentPageSx } from '@/styles/page'
+import type { Artwork } from '@/types/artwork'
+import type { S3ObjectReference } from '@/types/blockchain'
+
+type ArtistProfile = {
+  id: string
+  name: string
+  profileImageUrl: string
+  backgroundImageUrl?: string
+  role?: string
+  university?: string
+  department?: string
+  bio?: string
+}
+
+type ArtistArtworkDoc = {
+  artworkId?: string
+  ownerUid?: string
+  title?: string
+  status?: string
+  description?: string
+  thumbnailContentId?: string | null
+  images?: Array<{
+    contentId?: string
+    imageName?: string
+    storage?: S3ObjectReference
+  }>
+  category?: string
+  productionStart?: string
+  productionEnd?: string
+  productionYear?: number
+  availableForSale?: boolean
+  createdAt?: string
+  artistName?: string
+}
+
+function resolveStorageUrl(storage?: S3ObjectReference): Promise<string> {
+  const fallbackUrl = '/primary_default.png'
+
+  if (!storage?.bucketName || !storage.objectKey) {
+    return Promise.resolve(fallbackUrl)
+  }
+
+  const endpoint = import.meta.env.VITE_PRESIGNED_DOWNLOAD_ENDPOINT
+  if (!endpoint) {
+    return Promise.resolve(fallbackUrl)
+  }
+
+  return fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      bucketName: storage.bucketName,
+      objectKey: storage.objectKey,
+    }),
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        return fallbackUrl
+      }
+
+      const payload = (await response.json()) as { url?: string }
+      return payload.url || fallbackUrl
+    })
+    .catch(() => fallbackUrl)
+}
+
+function mapArtistArtwork(docSnapshot: ArtistArtworkDoc): Artwork {
+  return {
+    id: docSnapshot.artworkId ?? '',
+    artistId: docSnapshot.ownerUid ?? '',
+    categoryId: docSnapshot.category ?? '',
+    artist: {
+      id: docSnapshot.ownerUid ?? '',
+      name: docSnapshot.artistName ?? 'Unknown artist',
+    },
+    title: docSnapshot.title ?? 'Untitled artwork',
+    description: docSnapshot.description ?? '',
+    thumbnailUrl: '/primary_default.png',
+    thumbnailAlt: docSnapshot.title ?? 'Artwork',
+    productionStartDate: docSnapshot.productionStart ?? '',
+    productionEndDate: docSnapshot.productionEnd ?? '',
+    productionYear: docSnapshot.productionYear ?? new Date().getFullYear(),
+    isForSale: Boolean(docSnapshot.availableForSale),
+    viewCount: 0,
+    likeCount: 0,
+    status: 'approved',
+    contents: [],
+    createdAt: docSnapshot.createdAt ?? new Date().toISOString(),
+  }
+}
+
+function ArtistProfilePage() {
+  const { id = '' } = useParams()
+  const [artist, setArtist] = useState<ArtistProfile | null>(null)
+  const [artworks, setArtworks] = useState<Artwork[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadArtistProfile = async () => {
+      setIsLoading(true)
+      setErrorMessage('')
+
+      try {
+        const artistSnapshot = await getDoc(doc(db, 'users', id))
+        const artistData = artistSnapshot.data()
+
+        if (!artistSnapshot.exists() || !artistData) {
+          if (isMounted) {
+            setArtist(null)
+            setArtworks([])
+          }
+          return
+        }
+
+        const nextArtist: ArtistProfile = {
+          id,
+          name:
+            typeof artistData.name === 'string' && artistData.name.trim()
+              ? artistData.name
+              : 'Unknown artist',
+          profileImageUrl:
+            typeof artistData.profileImageUrl === 'string' &&
+            artistData.profileImageUrl.trim()
+              ? artistData.profileImageUrl
+              : DEFAULT_PROFILE_IMAGE_URL,
+          backgroundImageUrl:
+            typeof artistData.backgroundImageUrl === 'string'
+              ? artistData.backgroundImageUrl
+              : undefined,
+          role:
+            typeof artistData.role === 'string' ? artistData.role : undefined,
+          university:
+            typeof artistData.university === 'string'
+              ? artistData.university
+              : undefined,
+          department:
+            typeof artistData.department === 'string'
+              ? artistData.department
+              : undefined,
+          bio: typeof artistData.bio === 'string' ? artistData.bio : undefined,
+        }
+
+        const artworksQuery = query(
+          collection(db, 'artworks'),
+          where('ownerUid', '==', id)
+        )
+        const artworkSnapshot = await getDocs(artworksQuery)
+
+        const nextArtworks = await Promise.all(
+          artworkSnapshot.docs.map(async (snapshot) => {
+            const data = snapshot.data() as ArtistArtworkDoc
+            if (data.status !== 'approved') {
+              return null
+            }
+            const imageEntry =
+              data.images?.find(
+                (image) => image.contentId === data.thumbnailContentId
+              ) ?? data.images?.[0]
+            const thumbnailUrl = await resolveStorageUrl(imageEntry?.storage)
+
+            return {
+              ...mapArtistArtwork(data),
+              thumbnailUrl,
+            }
+          })
+        )
+
+        if (isMounted) {
+          setArtist(nextArtist)
+          setArtworks(
+            nextArtworks.filter((value): value is Artwork => Boolean(value))
+          )
+        }
+      } catch (error) {
+        if (isMounted) {
+          setErrorMessage(
+            error instanceof Error
+              ? error.message
+              : 'Failed to load artist profile.'
+          )
+          setArtist(null)
+          setArtworks([])
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void loadArtistProfile()
+
+    return () => {
+      isMounted = false
+    }
+  }, [id])
+
+  if (isLoading) {
+    return (
+      <Box component="main" sx={contentPageSx}>
+        <Stack spacing={2} sx={contentContainerSx}>
+          <Typography variant="h3">Artist Profile</Typography>
+          <Typography color="text.secondary">
+            Loading artist profile...
+          </Typography>
+        </Stack>
+      </Box>
+    )
+  }
+
+  if (!artist) {
+    return (
+      <Box component="main" sx={contentPageSx}>
+        <Stack spacing={2} sx={contentContainerSx}>
+          <Typography variant="h3">Artist Profile</Typography>
+          <Alert severity="info">No public artist profile was found.</Alert>
+        </Stack>
+      </Box>
+    )
+  }
+
+  return (
+    <Box component="main" sx={contentPageSx}>
+      <Stack spacing={4} sx={contentContainerSx}>
+        <Paper
+          sx={{
+            overflow: 'hidden',
+            borderRadius: 4,
+            background: artist.backgroundImageUrl
+              ? `linear-gradient(180deg, rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.55)), url(${artist.backgroundImageUrl}) center/cover`
+              : 'linear-gradient(135deg, rgba(15, 23, 42, 0.08), rgba(15, 23, 42, 0.02))',
+          }}
+        >
+          <Stack
+            spacing={2}
+            sx={{ p: { xs: 3, md: 5 }, color: 'common.white' }}
+          >
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={2.5}
+              alignItems={{ sm: 'center' }}
+            >
+              <Avatar
+                src={artist.profileImageUrl}
+                alt={artist.name}
+                sx={{
+                  width: 88,
+                  height: 88,
+                  border: '3px solid rgba(255,255,255,0.8)',
+                }}
+              />
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="overline" sx={{ opacity: 0.9 }}>
+                  Artist profile
+                </Typography>
+                <Typography variant="h3" sx={{ color: 'inherit' }}>
+                  {artist.name}
+                </Typography>
+                <Typography sx={{ opacity: 0.9 }}>
+                  {[artist.university, artist.department]
+                    .filter(Boolean)
+                    .join(' · ') || 'Public artist profile'}
+                </Typography>
+              </Box>
+            </Stack>
+
+            {artist.bio ? (
+              <Typography
+                sx={{ maxWidth: 780, whiteSpace: 'pre-line', opacity: 0.95 }}
+              >
+                {artist.bio}
+              </Typography>
+            ) : null}
+          </Stack>
+        </Paper>
+
+        <Stack spacing={1}>
+          <Typography variant="h5">Featured works</Typography>
+          <Typography color="text.secondary">
+            Approved artworks by this artist.
+          </Typography>
+        </Stack>
+
+        {errorMessage ? <Alert severity="error">{errorMessage}</Alert> : null}
+
+        {artworks.length > 0 ? (
+          <Box>
+            <Stack spacing={3}>
+              {artworks.map((artwork) => (
+                <ArtworkCard artwork={artwork} key={artwork.id} />
+              ))}
+            </Stack>
+          </Box>
+        ) : (
+          <Alert severity="info">No approved artworks are available yet.</Alert>
+        )}
+
+        <Typography
+          component={RouterLink}
+          to="/gallery"
+          sx={{
+            color: 'text.secondary',
+            textDecoration: 'none',
+            width: 'fit-content',
+          }}
+        >
+          Back to gallery
+        </Typography>
+      </Stack>
+    </Box>
+  )
+}
+
+export default ArtistProfilePage

--- a/src/pages/ArtworkDetailPage/index.tsx
+++ b/src/pages/ArtworkDetailPage/index.tsx
@@ -1,17 +1,79 @@
 import { useEffect, useState } from 'react'
-import { useLocation, useParams } from 'react-router-dom'
+import {
+  Link as RouterLink,
+  useLocation,
+  useNavigate,
+  useParams,
+} from 'react-router-dom'
 
+import FavoriteIcon from '@mui/icons-material/Favorite'
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined'
+import Masonry from '@mui/lab/Masonry'
 import Alert from '@mui/material/Alert'
+import Avatar from '@mui/material/Avatar'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import Divider from '@mui/material/Divider'
+import Link from '@mui/material/Link'
+import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import { onAuthStateChanged } from 'firebase/auth'
+import {
+  arrayRemove,
+  arrayUnion,
+  doc,
+  getDoc,
+  updateDoc,
+} from 'firebase/firestore'
 
+import { DEFAULT_PROFILE_IMAGE_URL } from '@/constants/profileIcons'
+import { auth, db } from '@/firebase/config'
 import { contentContainerSx, contentPageSx } from '@/styles/page'
 import type { Artwork } from '@/types/artwork'
-import type { ProtectedArtworkRecord } from '@/types/blockchain'
+import type {
+  ProtectedArtworkRecord,
+  S3ObjectReference,
+} from '@/types/blockchain'
 import { requestProtectedArtworkStatus } from '@/utils/protection'
+
+type ArtworkImage = {
+  contentId?: string
+  imageName?: string
+  storage?: S3ObjectReference
+}
+
+type ArtworkDoc = {
+  artworkId?: string
+  ownerUid?: string
+  title?: string
+  category?: string
+  description?: string
+  creationProcess?: string
+  relatedVideo?: string
+  productionStart?: string
+  productionEnd?: string
+  productionYear?: number
+  availableForSale?: boolean
+  images?: ArtworkImage[]
+  thumbnailContentId?: string | null
+  artistName?: string | null
+  createdAt?: string
+  likeCount?: number
+}
+
+type ArtistProfile = {
+  id: string
+  name: string
+  profileImageUrl: string
+  backgroundImageUrl?: string
+  role?: string
+  university?: string
+  department?: string
+}
 
 const statusChipColor = {
   upload_requested: 'info',
@@ -24,24 +86,315 @@ const statusChipColor = {
   failed: 'error',
 } as const
 
+function resolveStorageUrl(storage?: S3ObjectReference): Promise<string> {
+  const fallbackUrl = '/primary_default.png'
+
+  if (!storage?.bucketName || !storage.objectKey) {
+    return Promise.resolve(fallbackUrl)
+  }
+
+  const endpoint = import.meta.env.VITE_PRESIGNED_DOWNLOAD_ENDPOINT
+
+  if (!endpoint) {
+    return Promise.resolve(fallbackUrl)
+  }
+
+  return fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      bucketName: storage.bucketName,
+      objectKey: storage.objectKey,
+    }),
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        return fallbackUrl
+      }
+
+      const payload = (await response.json()) as { url?: string }
+      return payload.url || fallbackUrl
+    })
+    .catch(() => fallbackUrl)
+}
+
+function buildVideoEmbedUrl(videoUrl?: string) {
+  if (!videoUrl) {
+    return ''
+  }
+
+  try {
+    const url = new URL(videoUrl)
+
+    if (url.hostname.includes('youtu.be')) {
+      const videoId = url.pathname.replace('/', '')
+      return videoId ? `https://www.youtube.com/embed/${videoId}` : ''
+    }
+
+    if (url.hostname.includes('youtube.com')) {
+      const videoId = url.searchParams.get('v')
+      return videoId ? `https://www.youtube.com/embed/${videoId}` : ''
+    }
+
+    if (url.hostname.includes('vimeo.com')) {
+      const videoId = url.pathname.split('/').filter(Boolean).at(-1)
+      return videoId ? `https://player.vimeo.com/video/${videoId}` : ''
+    }
+
+    return videoUrl
+  } catch {
+    return ''
+  }
+}
+
+function formatProductionPeriod(artwork: ArtworkDoc) {
+  const start = artwork.productionStart?.trim()
+  const end = artwork.productionEnd?.trim()
+
+  if (start && end) {
+    return `${start} - ${end}`
+  }
+
+  if (start) {
+    return start
+  }
+
+  if (artwork.productionYear) {
+    return String(artwork.productionYear)
+  }
+
+  return 'Not specified'
+}
+
+function mapArtworkState(artwork: Artwork): ArtworkDoc {
+  return {
+    artworkId: artwork.id,
+    ownerUid: artwork.artistId,
+    title: artwork.title,
+    category: artwork.categoryId,
+    description: artwork.description,
+    creationProcess: artwork.creationProcess,
+    relatedVideo: artwork.videoUrl,
+    productionStart: artwork.productionStartDate,
+    productionEnd: artwork.productionEndDate,
+    productionYear: artwork.productionYear,
+    availableForSale: artwork.isForSale,
+    images: artwork.contents
+      .filter((content) => content.type === 'image')
+      .map((content) => ({
+        contentId: content.id,
+        imageName: content.alt,
+        storage: content.originalStorage,
+      })),
+    thumbnailContentId: artwork.contents.find(
+      (content) => content.thumbnailUrl || content.displayUrl
+    )?.id,
+    artistName: artwork.artist.name,
+    createdAt: artwork.createdAt,
+    likeCount: artwork.likeCount,
+  }
+}
+
 function ArtworkDetailPage() {
   const { id = '' } = useParams()
-  const [artwork, setArtwork] = useState<ProtectedArtworkRecord | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const navigate = useNavigate()
   const location = useLocation()
   const navState = location.state as { artwork?: Artwork } | null
-  const navArtwork = navState?.artwork
+
+  const [artwork, setArtwork] = useState<ArtworkDoc | null>(null)
+  const [artist, setArtist] = useState<ArtistProfile | null>(null)
+  const [protection, setProtection] = useState<ProtectedArtworkRecord | null>(
+    null
+  )
+  const [imageUrls, setImageUrls] = useState<string[]>([])
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null)
+  const [likedArtworkIds, setLikedArtworkIds] = useState<string[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isUpdatingLike, setIsUpdatingLike] = useState(false)
+  const [noticeMessage, setNoticeMessage] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      setCurrentUserId(user?.uid ?? null)
+
+      if (!user) {
+        setLikedArtworkIds([])
+        return
+      }
+
+      try {
+        const userSnapshot = await getDoc(doc(db, 'users', user.uid))
+        const likedArtworkIdsFromProfile = userSnapshot.data()?.likedArtworkIds
+
+        setLikedArtworkIds(
+          Array.isArray(likedArtworkIdsFromProfile)
+            ? likedArtworkIdsFromProfile.filter(
+                (value): value is string => typeof value === 'string'
+              )
+            : []
+        )
+      } catch {
+        setLikedArtworkIds([])
+      }
+    })
+
+    return unsubscribe
+  }, [])
 
   useEffect(() => {
     let isMounted = true
 
     const loadArtwork = async () => {
       setIsLoading(true)
-      const nextArtwork = await requestProtectedArtworkStatus({ artworkId: id })
+      setErrorMessage('')
+      setNoticeMessage('')
 
-      if (isMounted) {
-        setArtwork(nextArtwork)
-        setIsLoading(false)
+      try {
+        const snapshot = await getDoc(doc(db, 'artworks', id))
+        const stateArtwork = navState?.artwork
+          ? mapArtworkState(navState.artwork)
+          : null
+        const nextArtwork = snapshot.exists()
+          ? (snapshot.data() as ArtworkDoc)
+          : stateArtwork
+
+        if (!nextArtwork) {
+          if (isMounted) {
+            setArtwork(null)
+            setArtist(null)
+            setProtection(null)
+            setImageUrls([])
+          }
+          return
+        }
+
+        const normalizedArtwork: ArtworkDoc = {
+          ...nextArtwork,
+          artworkId: nextArtwork.artworkId ?? id,
+        }
+
+        const images = normalizedArtwork.images ?? []
+        const thumbnailContentId = normalizedArtwork.thumbnailContentId
+        const orderedImages = [...images].sort((left, right) => {
+          if (left.contentId === thumbnailContentId) {
+            return -1
+          }
+
+          if (right.contentId === thumbnailContentId) {
+            return 1
+          }
+
+          return 0
+        })
+
+        const nextImageUrls = await Promise.all(
+          orderedImages.map(async (image) => {
+            const resolvedUrl = await resolveStorageUrl(image.storage)
+            return resolvedUrl
+          })
+        )
+
+        if (isMounted) {
+          setArtwork(normalizedArtwork)
+          setImageUrls(
+            nextImageUrls.length > 0
+              ? nextImageUrls
+              : normalizedArtwork.images?.length
+                ? []
+                : normalizedArtwork.relatedVideo
+                  ? []
+                  : [navState?.artwork?.thumbnailUrl ?? '/primary_default.png']
+          )
+        }
+
+        const ownerUid = normalizedArtwork.ownerUid
+        if (ownerUid) {
+          try {
+            const artistSnapshot = await getDoc(doc(db, 'users', ownerUid))
+            const artistData = artistSnapshot.data()
+
+            if (isMounted && artistData) {
+              setArtist({
+                id: ownerUid,
+                name:
+                  typeof artistData.name === 'string' && artistData.name.trim()
+                    ? artistData.name
+                    : normalizedArtwork.artistName || 'Unknown artist',
+                profileImageUrl:
+                  typeof artistData.profileImageUrl === 'string' &&
+                  artistData.profileImageUrl.trim()
+                    ? artistData.profileImageUrl
+                    : DEFAULT_PROFILE_IMAGE_URL,
+                backgroundImageUrl:
+                  typeof artistData.backgroundImageUrl === 'string'
+                    ? artistData.backgroundImageUrl
+                    : undefined,
+                role:
+                  typeof artistData.role === 'string'
+                    ? artistData.role
+                    : undefined,
+                university:
+                  typeof artistData.university === 'string'
+                    ? artistData.university
+                    : undefined,
+                department:
+                  typeof artistData.department === 'string'
+                    ? artistData.department
+                    : undefined,
+              })
+            }
+          } catch {
+            if (isMounted) {
+              setArtist(
+                normalizedArtwork.artistName
+                  ? {
+                      id: ownerUid,
+                      name: normalizedArtwork.artistName,
+                      profileImageUrl: DEFAULT_PROFILE_IMAGE_URL,
+                    }
+                  : null
+              )
+            }
+          }
+        }
+
+        try {
+          const protectionRecord = await requestProtectedArtworkStatus({
+            artworkId: normalizedArtwork.artworkId ?? id,
+          })
+
+          if (isMounted) {
+            setProtection(protectionRecord)
+          }
+        } catch (protectionError) {
+          if (isMounted) {
+            setProtection(null)
+            setNoticeMessage(
+              protectionError instanceof Error
+                ? protectionError.message
+                : 'Blockchain protection status is temporarily unavailable.'
+            )
+          }
+        }
+      } catch (error) {
+        if (isMounted) {
+          setErrorMessage(
+            error instanceof Error
+              ? error.message
+              : 'Failed to load artwork detail.'
+          )
+          setArtwork(null)
+          setArtist(null)
+          setProtection(null)
+          setImageUrls([])
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
       }
     }
 
@@ -50,7 +403,80 @@ function ArtworkDetailPage() {
     return () => {
       isMounted = false
     }
-  }, [id])
+  }, [id, navState?.artwork])
+
+  const likeCount = artwork?.likeCount ?? 0
+  const isLiked = Boolean(id && likedArtworkIds.includes(id))
+  const displayImages =
+    imageUrls.length > 0
+      ? imageUrls
+      : navState?.artwork?.thumbnailUrl
+        ? [navState.artwork.thumbnailUrl]
+        : artwork?.images?.length
+          ? ['/primary_default.png']
+          : []
+
+  const handleToggleLike = async () => {
+    if (!currentUserId) {
+      navigate('/login')
+      return
+    }
+
+    if (!id || isUpdatingLike) {
+      return
+    }
+
+    setIsUpdatingLike(true)
+    setErrorMessage('')
+
+    const userRef = doc(db, 'users', currentUserId)
+    const nextLiked = isLiked
+      ? likedArtworkIds.filter((artworkId) => artworkId !== id)
+      : [...likedArtworkIds, id]
+
+    try {
+      await updateDoc(userRef, {
+        likedArtworkIds: isLiked ? arrayRemove(id) : arrayUnion(id),
+      })
+
+      setLikedArtworkIds(nextLiked)
+      setArtwork((currentArtwork) =>
+        currentArtwork
+          ? {
+              ...currentArtwork,
+              likeCount: Math.max(
+                0,
+                (currentArtwork.likeCount ?? 0) + (isLiked ? -1 : 1)
+              ),
+            }
+          : currentArtwork
+      )
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Failed to update like.'
+      )
+    } finally {
+      setIsUpdatingLike(false)
+    }
+  }
+
+  const handleShare = async () => {
+    const shareUrl = window.location.href
+
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      setNoticeMessage('Link copied to clipboard.')
+    } catch {
+      setNoticeMessage('Failed to copy link to clipboard.')
+    }
+  }
+
+  const protectionStatus = protection?.protection.status
+  const protectionStatusLabel = protectionStatus
+    ? protectionStatus.replace(/_/g, ' ').toUpperCase()
+    : 'NOT AVAILABLE'
+
+  const protectionSummary = protection?.protection
 
   if (isLoading) {
     return (
@@ -69,97 +495,315 @@ function ArtworkDetailPage() {
         <Stack spacing={4} sx={contentContainerSx}>
           <Typography variant="h3">Artwork Detail</Typography>
           <Alert severity="info">
-            No stored record found for this artwork ID.
+            No stored record found for this artwork.
           </Alert>
         </Stack>
       </Box>
     )
   }
 
-  const { protection } = artwork
-
   return (
     <Box component="main" sx={contentPageSx}>
       <Stack spacing={4} sx={contentContainerSx}>
-        <Typography variant="h3">Artwork Detail</Typography>
-
-        {navArtwork ? (
-          <Box sx={{ mt: 2 }}>
-            <Box
-              component="img"
-              src={navArtwork.thumbnailUrl}
-              alt={navArtwork.thumbnailAlt}
-              sx={{ maxWidth: '100%', borderRadius: 2 }}
+        <Stack spacing={1.5}>
+          <Typography variant="overline" color="text.secondary">
+            Artwork detail
+          </Typography>
+          <Typography variant="h3">
+            {artwork.title ?? 'Untitled artwork'}
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" spacing={1}>
+            {artwork.category ? <Chip label={artwork.category} /> : null}
+            <Chip
+              label={artwork.availableForSale ? 'For sale' : 'Not for sale'}
+              color={artwork.availableForSale ? 'success' : 'default'}
+              variant="outlined"
             />
+            <Chip label={`Likes ${likeCount}`} variant="outlined" />
+          </Stack>
+        </Stack>
+
+        {errorMessage ? <Alert severity="error">{errorMessage}</Alert> : null}
+        {noticeMessage ? <Alert severity="info">{noticeMessage}</Alert> : null}
+
+        <Stack
+          alignItems="flex-start"
+          direction={{ xs: 'column', lg: 'row' }}
+          spacing={4}
+        >
+          <Box sx={{ flex: 1.4, minWidth: 0, width: '100%' }}>
+            {displayImages.length > 0 ? (
+              <Masonry columns={{ xs: 1, sm: 2 }} spacing={2.25}>
+                {displayImages.map((imageUrl, index) => (
+                  <Box
+                    key={`${imageUrl}-${index}`}
+                    component="img"
+                    src={imageUrl}
+                    alt={`${artwork.title ?? 'Artwork'} image ${index + 1}`}
+                    onError={(event) => {
+                      const imageElement = event.target as HTMLImageElement
+                      imageElement.src = '/primary_default.png'
+                    }}
+                    sx={{
+                      width: '100%',
+                      display: 'block',
+                      borderRadius: 3,
+                      overflow: 'hidden',
+                      boxShadow: '0 16px 36px rgba(15, 23, 42, 0.12)',
+                    }}
+                  />
+                ))}
+              </Masonry>
+            ) : (
+              <Paper
+                variant="outlined"
+                sx={{
+                  p: 4,
+                  borderRadius: 3,
+                  textAlign: 'center',
+                }}
+              >
+                <Typography color="text.secondary">
+                  No artwork images are available.
+                </Typography>
+              </Paper>
+            )}
+
+            {artwork.relatedVideo ? (
+              <Paper
+                variant="outlined"
+                sx={{ mt: 3, p: { xs: 2, md: 3 }, borderRadius: 3 }}
+              >
+                <Stack spacing={2}>
+                  <Typography variant="h6">Related video</Typography>
+                  {buildVideoEmbedUrl(artwork.relatedVideo) ? (
+                    <Box
+                      sx={{
+                        position: 'relative',
+                        overflow: 'hidden',
+                        borderRadius: 2,
+                        pt: '56.25%',
+                      }}
+                    >
+                      <Box
+                        component="iframe"
+                        src={buildVideoEmbedUrl(artwork.relatedVideo)}
+                        title={`${artwork.title ?? 'Artwork'} video`}
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        allowFullScreen
+                        sx={{
+                          position: 'absolute',
+                          inset: 0,
+                          width: '100%',
+                          height: '100%',
+                          border: 0,
+                        }}
+                      />
+                    </Box>
+                  ) : (
+                    <Link
+                      href={artwork.relatedVideo}
+                      target="_blank"
+                      rel="noreferrer"
+                      sx={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 0.5,
+                      }}
+                    >
+                      Open related video
+                      <OpenInNewIcon fontSize="small" />
+                    </Link>
+                  )}
+                </Stack>
+              </Paper>
+            ) : null}
           </Box>
-        ) : null}
 
-        <Stack spacing={1}>
-          <Typography variant="h5">{artwork.title}</Typography>
-          <Typography color="text.secondary">ID: {artwork.id}</Typography>
-          <Typography color="text.secondary">
-            Content ID: {artwork.contentId ?? 'Not assigned yet'}
-          </Typography>
-          <Typography color="text.secondary">
-            Uploaded file: {artwork.imageName}
-          </Typography>
-          <Typography color="text.secondary">
-            Owner: {artwork.ownerUid ?? 'Unknown'}
-          </Typography>
-        </Stack>
+          <Box
+            sx={{
+              flex: 0.85,
+              minWidth: 0,
+              width: '100%',
+              position: { lg: 'sticky' },
+              top: { lg: 24 },
+            }}
+          >
+            <Stack spacing={2.5}>
+              <Paper variant="outlined" sx={{ p: 3, borderRadius: 3 }}>
+                <Stack spacing={2}>
+                  <Stack alignItems="center" direction="row" spacing={1.5}>
+                    <Avatar
+                      src={artist?.profileImageUrl}
+                      alt={artist?.name ?? artwork.artistName ?? 'Artist'}
+                      sx={{ width: 56, height: 56 }}
+                    />
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography variant="overline" color="text.secondary">
+                        Artist
+                      </Typography>
+                      <Typography
+                        component={RouterLink}
+                        to={artist?.id ? `/artists/${artist.id}` : '#'}
+                        sx={{
+                          display: 'block',
+                          fontSize: '1.1rem',
+                          fontWeight: 700,
+                          color: 'text.primary',
+                          textDecoration: 'none',
+                          '&:hover': { textDecoration: 'underline' },
+                        }}
+                      >
+                        {artist?.name ?? artwork.artistName ?? 'Unknown artist'}
+                      </Typography>
+                      {artist?.university || artist?.department ? (
+                        <Typography variant="body2" color="text.secondary">
+                          {[artist.university, artist.department]
+                            .filter(Boolean)
+                            .join(' · ')}
+                        </Typography>
+                      ) : null}
+                    </Box>
+                  </Stack>
 
-        <Divider />
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      fullWidth
+                      variant={isLiked ? 'contained' : 'outlined'}
+                      onClick={handleToggleLike}
+                      disabled={isUpdatingLike}
+                      startIcon={
+                        isLiked ? <FavoriteIcon /> : <FavoriteBorderIcon />
+                      }
+                    >
+                      {currentUserId
+                        ? isLiked
+                          ? 'Liked'
+                          : 'Like'
+                        : 'Sign in to like'}
+                    </Button>
+                    <Button
+                      fullWidth
+                      variant="outlined"
+                      onClick={handleShare}
+                      startIcon={<ShareOutlinedIcon />}
+                    >
+                      Share
+                    </Button>
+                  </Stack>
+                </Stack>
+              </Paper>
 
-        <Stack spacing={1.5}>
-          <Typography variant="h6">Protection Status</Typography>
-          <Chip
-            color={statusChipColor[protection.status]}
-            label={protection.status.toUpperCase()}
-            sx={{ width: 'fit-content' }}
-          />
-          <Typography>
-            Requested at: {protection.requestedAt ?? 'Not assigned yet'}
-          </Typography>
-          <Typography>
-            Uploaded at: {protection.uploadedAt ?? 'Not uploaded yet'}
-          </Typography>
-          <Typography>
-            Approved at: {protection.approvedAt ?? 'Not approved yet'}
-          </Typography>
-          <Typography>
-            Chain: {protection.chainName ?? 'Not assigned yet'}
-          </Typography>
-          <Typography>
-            Blockchain tx hash: {protection.blockchainTxHash ?? 'Not available'}
-          </Typography>
+              <Paper variant="outlined" sx={{ p: 3, borderRadius: 3 }}>
+                <Stack spacing={2.25}>
+                  <Box>
+                    <Typography variant="overline" color="text.secondary">
+                      Category
+                    </Typography>
+                    <Typography>
+                      {artwork.category ?? 'Not specified'}
+                    </Typography>
+                  </Box>
 
-          {protection.errorMessage ? (
-            <Alert severity="error">{protection.errorMessage}</Alert>
-          ) : null}
-        </Stack>
+                  <Box>
+                    <Typography variant="overline" color="text.secondary">
+                      Artwork description
+                    </Typography>
+                    <Typography sx={{ whiteSpace: 'pre-line' }}>
+                      {artwork.description?.trim() ||
+                        'No description provided.'}
+                    </Typography>
+                  </Box>
 
-        <Divider />
+                  <Box>
+                    <Typography variant="overline" color="text.secondary">
+                      Creation process
+                    </Typography>
+                    <Typography sx={{ whiteSpace: 'pre-line' }}>
+                      {artwork.creationProcess?.trim() ||
+                        'No creation process provided.'}
+                    </Typography>
+                  </Box>
 
-        <Stack spacing={1.5}>
-          <Typography variant="h6">Integrity Metadata</Typography>
-          <Typography sx={{ wordBreak: 'break-all' }}>
-            Image hash (SHA-256): {protection.imageHash ?? 'Not computed yet'}
-          </Typography>
-          <Typography>
-            IPFS CID: {protection.ipfsCid ?? 'Not assigned yet'}
-          </Typography>
-          <Typography>
-            Storage provider: {protection.storage.provider}
-          </Typography>
-          <Typography>Bucket: {protection.storage.bucketName}</Typography>
-          <Typography sx={{ wordBreak: 'break-all' }}>
-            Object key: {protection.storage.objectKey}
-          </Typography>
-          <Typography>Region: {protection.storage.region}</Typography>
-          <Typography>
-            Verified content length:{' '}
-            {protection.verifiedStorage?.contentLength ?? 'Not verified yet'}
-          </Typography>
+                  <Divider />
+
+                  <Box>
+                    <Typography variant="overline" color="text.secondary">
+                      Production period
+                    </Typography>
+                    <Typography>{formatProductionPeriod(artwork)}</Typography>
+                  </Box>
+
+                  <Box>
+                    <Typography variant="overline" color="text.secondary">
+                      Sale availability
+                    </Typography>
+                    <Typography>
+                      {artwork.availableForSale
+                        ? 'Available for sale'
+                        : 'Not available for sale'}
+                    </Typography>
+                  </Box>
+                </Stack>
+              </Paper>
+
+              <Paper variant="outlined" sx={{ p: 3, borderRadius: 3 }}>
+                <Stack spacing={1.5}>
+                  <Typography variant="h6">
+                    Blockchain protection status
+                  </Typography>
+                  <Chip
+                    color={
+                      protectionStatus
+                        ? statusChipColor[protectionStatus]
+                        : 'default'
+                    }
+                    label={protectionStatusLabel}
+                    sx={{ width: 'fit-content' }}
+                  />
+
+                  <Typography>
+                    Requested at:{' '}
+                    {protectionSummary?.requestedAt ?? 'Not assigned yet'}
+                  </Typography>
+                  <Typography>
+                    Uploaded at:{' '}
+                    {protectionSummary?.uploadedAt ?? 'Not uploaded yet'}
+                  </Typography>
+                  <Typography>
+                    Approved at:{' '}
+                    {protectionSummary?.approvedAt ?? 'Not approved yet'}
+                  </Typography>
+                  <Typography>
+                    Chain: {protectionSummary?.chainName ?? 'Not assigned yet'}
+                  </Typography>
+                  <Typography sx={{ wordBreak: 'break-all' }}>
+                    Blockchain tx hash:{' '}
+                    {protectionSummary?.blockchainTxHash ?? 'Not available'}
+                  </Typography>
+
+                  {protectionSummary?.imageHash ? (
+                    <Typography sx={{ wordBreak: 'break-all' }}>
+                      Image hash: {protectionSummary.imageHash}
+                    </Typography>
+                  ) : null}
+
+                  {protectionSummary?.verifiedStorage?.contentLength ? (
+                    <Typography>
+                      Verified content length:{' '}
+                      {protectionSummary.verifiedStorage.contentLength}
+                    </Typography>
+                  ) : null}
+
+                  {protectionSummary?.errorMessage ? (
+                    <Alert severity="error">
+                      {protectionSummary.errorMessage}
+                    </Alert>
+                  ) : null}
+                </Stack>
+              </Paper>
+            </Stack>
+          </Box>
         </Stack>
       </Stack>
     </Box>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router-dom'
 
 import Layout from '@/layouts'
 import AdminPage from '@/pages/AdminPage'
+import ArtistProfilePage from '@/pages/ArtistProfilePage'
 import ArtworkDetailPage from '@/pages/ArtworkDetailPage'
 import ArtworkManagementPage from '@/pages/ArtworkManagementPage'
 import GalleryPage from '@/pages/GalleryPage'
@@ -20,6 +21,7 @@ export const router = createBrowserRouter([
       { index: true, element: <HomePage /> },
       { path: 'gallery', element: <GalleryPage /> },
       { path: 'artworks/:id', element: <ArtworkDetailPage /> },
+      { path: 'artists/:id', element: <ArtistProfilePage /> },
       { path: 'login', element: <LoginPage /> },
       { path: 'signup', element: <SignupPage /> },
       { path: 'submit', element: <SubmitArtworkPage /> },


### PR DESCRIPTION
## Summary

Implement the artwork detail page so users can view full artwork information, protection status, and artist context from the gallery flow. This PR also adds an artist profile page linked from artwork detail to improve navigation between artworks and creators.

## Changes

- expand `ArtworkDetailPage` to load artwork data from Firestore and render images, metadata, creation process, sale status, and related video
- add blockchain protection status section with hash, tx hash, chain, and verification metadata
- add like/share/contact actions on artwork detail, including login redirect for unauthenticated users
- add `ArtistProfilePage` and route `/artists/:id` to show public artist information and approved artworks
- add route wiring for artwork detail and artist profile navigation
- add MUI icon dependency used by the new detail page actions

## Why

The gallery previously lacked a dedicated artwork detail experience, which made it hard for users to inspect a work beyond the thumbnail list. This change provides a complete detail view, exposes protection information that supports trust in the artwork, and improves discovery by linking users to the artist’s public profile and other approved works.

## Testing
- [x] `npm run build`
- [x] manual check completed
- [ ] not tested

## Notes
<img width="1241" height="793" alt="image" src="https://github.com/user-attachments/assets/7b0c85e4-7810-46e3-9aed-1aedbac04f73" />

