### PR TITLE
issue#15 Profile, notification

### DIFF
--- a/src/components/ContactDialog/index.tsx
+++ b/src/components/ContactDialog/index.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from 'react'
+
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import Stack from '@mui/material/Stack'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
+import Typography from '@mui/material/Typography'
+
+import type { ContactContextType, ContactIntent } from '@/types/notification'
+import {
+  getContactContextLabel,
+  getContactIntentLabel,
+} from '@/utils/notifications'
+
+const contactIntentOptions: Record<ContactContextType, ContactIntent[]> = {
+  artwork: ['purchase', 'collaboration'],
+  profile: ['collaboration', 'career'],
+}
+
+interface ContactDialogProps {
+  open: boolean
+  contextType: ContactContextType
+  recipientName: string
+  artworkTitle?: string
+  onClose: () => void
+  onSubmit: (contactIntent: ContactIntent) => Promise<void> | void
+}
+
+function ContactDialog({
+  artworkTitle,
+  contextType,
+  onClose,
+  onSubmit,
+  open,
+  recipientName,
+}: ContactDialogProps) {
+  const [selectedIntent, setSelectedIntent] = useState<ContactIntent>(
+    contactIntentOptions[contextType][0]
+  )
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setSelectedIntent(contactIntentOptions[contextType][0])
+    }
+  }, [contextType, open])
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true)
+
+    try {
+      await onSubmit(selectedIntent)
+      onClose()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog fullWidth maxWidth="sm" onClose={onClose} open={open}>
+      <DialogTitle>
+        Contact via {getContactContextLabel(contextType)}
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={2.5} sx={{ pt: 1 }}>
+          <Typography color="text.secondary">
+            {recipientName}
+            {contextType === 'artwork' && artworkTitle
+              ? `"${artworkTitle}"`
+              : 'Choose the intent for this contact request.'}
+          </Typography>
+
+          <ToggleButtonGroup
+            exclusive
+            fullWidth
+            onChange={(_, value: ContactIntent | null) => {
+              if (value) {
+                setSelectedIntent(value)
+              }
+            }}
+            value={selectedIntent}
+          >
+            {contactIntentOptions[contextType].map((intent) => (
+              <ToggleButton key={intent} value={intent}>
+                {getContactIntentLabel(intent)}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 3 }}>
+        <Button disabled={isSubmitting} onClick={onClose} variant="outlined">
+          Cancel
+        </Button>
+        <Button
+          disabled={isSubmitting}
+          onClick={handleSubmit}
+          variant="contained"
+        >
+          {isSubmitting ? 'Sending...' : 'Send request'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ContactDialog

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -34,6 +34,7 @@ const headerActionSx = {
 function Header() {
   const navigate = useNavigate()
   const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const [currentUserId, setCurrentUserId] = useState('')
   const [username, setUsername] = useState('User')
   const [profileImageUrl, setProfileImageUrl] = useState(
     DEFAULT_PROFILE_IMAGE_URL
@@ -50,6 +51,7 @@ function Header() {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       setIsLoggedIn(Boolean(user))
+      setCurrentUserId(user?.uid ?? '')
       setUsername(user?.displayName || user?.email || 'User')
       setProfileImageUrl(user?.photoURL || DEFAULT_PROFILE_IMAGE_URL)
 
@@ -73,6 +75,7 @@ function Header() {
     const refreshCurrentUser = async () => {
       if (!auth.currentUser) {
         setIsLoggedIn(false)
+        setCurrentUserId('')
         setUsername('User')
         setProfileImageUrl(DEFAULT_PROFILE_IMAGE_URL)
         return
@@ -105,7 +108,12 @@ function Header() {
 
   const goToProfile = () => {
     closeProfileMenu()
-    navigate('/profile')
+    navigate(currentUserId ? `/profile/${currentUserId}` : '/profile')
+  }
+
+  const goToMessages = () => {
+    closeProfileMenu()
+    navigate('/messages')
   }
 
   const handleLogout = async () => {
@@ -222,7 +230,13 @@ function Header() {
                     onClick={goToProfile}
                     sx={{ fontSize: '0.95rem', minHeight: 42, px: 2 }}
                   >
-                    Edit profile
+                    My profile
+                  </MenuItem>
+                  <MenuItem
+                    onClick={goToMessages}
+                    sx={{ fontSize: '0.95rem', minHeight: 42, px: 2 }}
+                  >
+                    Message box
                   </MenuItem>
                   {userRole === 'student' ? (
                     <MenuItem

--- a/src/firebase/auth.ts
+++ b/src/firebase/auth.ts
@@ -38,6 +38,12 @@ export interface LoginInput {
 export interface UpdateUserProfileInput {
   name: string
   profileImageUrl?: string
+  backgroundImageUrl?: string
+  country?: string
+  university?: string
+  department?: string
+  major?: string
+  expectedGraduationDate?: string
 }
 
 export const AUTH_PROFILE_UPDATED_EVENT = 'auth-profile-updated'
@@ -71,6 +77,7 @@ export async function signUpStudentWithEmail({
     profileImageUrl,
     university,
     department,
+    major: department,
     role: 'student',
     universityVerificationStatus: 'pending',
     createdAt: serverTimestamp(),
@@ -205,15 +212,13 @@ export async function updateCurrentUserProfile({
     photoURL: nextProfileImageUrl,
   })
 
-  await setDoc(
-    doc(db, 'users', user.uid),
-    {
-      name,
-      profileImageUrl: nextProfileImageUrl,
-      updatedAt: serverTimestamp(),
-    },
-    { merge: true }
-  )
+  const profileData: Record<string, unknown> = {
+    name,
+    profileImageUrl: nextProfileImageUrl,
+    updatedAt: serverTimestamp(),
+  }
+
+  await setDoc(doc(db, 'users', user.uid), profileData, { merge: true })
 
   window.dispatchEvent(new Event(AUTH_PROFILE_UPDATED_EVENT))
 

--- a/src/pages/ArtworkDetailPage/index.tsx
+++ b/src/pages/ArtworkDetailPage/index.tsx
@@ -23,13 +23,17 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { onAuthStateChanged } from 'firebase/auth'
 import {
-  arrayRemove,
-  arrayUnion,
+  collection,
+  deleteDoc,
   doc,
   getDoc,
-  updateDoc,
+  getDocs,
+  query,
+  setDoc,
+  where,
 } from 'firebase/firestore'
 
+import ContactDialog from '@/components/ContactDialog'
 import { DEFAULT_PROFILE_IMAGE_URL } from '@/constants/profileIcons'
 import { auth, db } from '@/firebase/config'
 import { contentContainerSx, contentPageSx } from '@/styles/page'
@@ -38,6 +42,8 @@ import type {
   ProtectedArtworkRecord,
   S3ObjectReference,
 } from '@/types/blockchain'
+import type { ContactIntent } from '@/types/notification'
+import { createContactNotification } from '@/utils/notifications'
 import { requestProtectedArtworkStatus } from '@/utils/protection'
 
 type ArtworkImage = {
@@ -211,10 +217,12 @@ function ArtworkDetailPage() {
   const [imageUrls, setImageUrls] = useState<string[]>([])
   const [currentUserId, setCurrentUserId] = useState<string | null>(null)
   const [likedArtworkIds, setLikedArtworkIds] = useState<string[]>([])
+  const [likeCount, setLikeCount] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
   const [isUpdatingLike, setIsUpdatingLike] = useState(false)
   const [noticeMessage, setNoticeMessage] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
+  const [isContactDialogOpen, setIsContactDialogOpen] = useState(false)
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
@@ -226,15 +234,15 @@ function ArtworkDetailPage() {
       }
 
       try {
-        const userSnapshot = await getDoc(doc(db, 'users', user.uid))
-        const likedArtworkIdsFromProfile = userSnapshot.data()?.likedArtworkIds
+        const likedSnapshot = await getDocs(
+          query(collection(db, 'likes'), where('userId', '==', user.uid))
+        )
 
         setLikedArtworkIds(
-          Array.isArray(likedArtworkIdsFromProfile)
-            ? likedArtworkIdsFromProfile.filter(
-                (value): value is string => typeof value === 'string'
-              )
-            : []
+          likedSnapshot.docs
+            .map((snapshot) => snapshot.data())
+            .map((record) => record.artworkId)
+            .filter((value): value is string => typeof value === 'string')
         )
       } catch {
         setLikedArtworkIds([])
@@ -299,6 +307,7 @@ function ArtworkDetailPage() {
 
         if (isMounted) {
           setArtwork(normalizedArtwork)
+          setLikeCount(normalizedArtwork.likeCount ?? 0)
           setImageUrls(
             nextImageUrls.length > 0
               ? nextImageUrls
@@ -362,6 +371,23 @@ function ArtworkDetailPage() {
         }
 
         try {
+          const likeSnapshot = await getDocs(
+            query(
+              collection(db, 'likes'),
+              where('artworkId', '==', normalizedArtwork.artworkId ?? id)
+            )
+          )
+
+          if (isMounted) {
+            setLikeCount(likeSnapshot.size)
+          }
+        } catch {
+          if (isMounted) {
+            setLikeCount(normalizedArtwork.likeCount ?? 0)
+          }
+        }
+
+        try {
           const protectionRecord = await requestProtectedArtworkStatus({
             artworkId: normalizedArtwork.artworkId ?? id,
           })
@@ -405,7 +431,6 @@ function ArtworkDetailPage() {
     }
   }, [id, navState?.artwork])
 
-  const likeCount = artwork?.likeCount ?? 0
   const isLiked = Boolean(id && likedArtworkIds.includes(id))
   const displayImages =
     imageUrls.length > 0
@@ -429,27 +454,25 @@ function ArtworkDetailPage() {
     setIsUpdatingLike(true)
     setErrorMessage('')
 
-    const userRef = doc(db, 'users', currentUserId)
     const nextLiked = isLiked
       ? likedArtworkIds.filter((artworkId) => artworkId !== id)
       : [...likedArtworkIds, id]
+    const likeDocId = `${currentUserId}_${id}`
 
     try {
-      await updateDoc(userRef, {
-        likedArtworkIds: isLiked ? arrayRemove(id) : arrayUnion(id),
-      })
+      if (isLiked) {
+        await deleteDoc(doc(db, 'likes', likeDocId))
+      } else {
+        await setDoc(doc(db, 'likes', likeDocId), {
+          userId: currentUserId,
+          artworkId: id,
+          createdAt: new Date().toISOString(),
+        })
+      }
 
       setLikedArtworkIds(nextLiked)
-      setArtwork((currentArtwork) =>
-        currentArtwork
-          ? {
-              ...currentArtwork,
-              likeCount: Math.max(
-                0,
-                (currentArtwork.likeCount ?? 0) + (isLiked ? -1 : 1)
-              ),
-            }
-          : currentArtwork
+      setLikeCount((currentCount) =>
+        Math.max(0, currentCount + (isLiked ? -1 : 1))
       )
     } catch (error) {
       setErrorMessage(
@@ -469,6 +492,30 @@ function ArtworkDetailPage() {
     } catch {
       setNoticeMessage('Failed to copy link to clipboard.')
     }
+  }
+
+  const handleContactArtist = async (contactIntent: ContactIntent) => {
+    if (!currentUserId) {
+      navigate('/login')
+      return
+    }
+
+    if (!artist?.id || !artwork?.artworkId) {
+      return
+    }
+
+    await createContactNotification({
+      receiverId: artist.id,
+      senderId: currentUserId,
+      senderName:
+        auth.currentUser?.displayName || auth.currentUser?.email || 'User',
+      contextType: 'artwork',
+      contactIntent,
+      artworkId: artwork.artworkId,
+      artworkTitle: artwork.title,
+    })
+
+    setNoticeMessage('Contact request sent.')
   }
 
   const protectionStatus = protection?.protection.status
@@ -691,6 +738,16 @@ function ArtworkDetailPage() {
                       Share
                     </Button>
                   </Stack>
+
+                  {artist?.id && artist.id !== currentUserId ? (
+                    <Button
+                      fullWidth
+                      onClick={() => setIsContactDialogOpen(true)}
+                      variant="contained"
+                    >
+                      Contact artist
+                    </Button>
+                  ) : null}
                 </Stack>
               </Paper>
 
@@ -806,6 +863,15 @@ function ArtworkDetailPage() {
           </Box>
         </Stack>
       </Stack>
+
+      <ContactDialog
+        artworkTitle={artwork.title}
+        contextType="artwork"
+        open={isContactDialogOpen}
+        onClose={() => setIsContactDialogOpen(false)}
+        onSubmit={handleContactArtist}
+        recipientName={artist?.name ?? artwork.artistName ?? 'Artist'}
+      />
     </Box>
   )
 }

--- a/src/pages/MessagesPage/index.tsx
+++ b/src/pages/MessagesPage/index.tsx
@@ -1,0 +1,356 @@
+import { useEffect, useState } from 'react'
+import { Link as RouterLink, useNavigate } from 'react-router-dom'
+
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { onAuthStateChanged } from 'firebase/auth'
+import { collection, getDocs, query, where } from 'firebase/firestore'
+
+import { auth, db } from '@/firebase/config'
+import { contentContainerSx, contentPageSx } from '@/styles/page'
+import type { Notification } from '@/types/notification'
+import {
+  getContactContextLabel,
+  getContactIntentLabel,
+} from '@/utils/notifications'
+
+type NotificationRecord = Notification & { id: string }
+
+type OwnedArtworkSummary = {
+  id: string
+  title: string
+  likeCount: number
+  status: string
+}
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('en-US')
+}
+
+function MessagesPage() {
+  const navigate = useNavigate()
+  const [currentUserId, setCurrentUserId] = useState('')
+  const [notifications, setNotifications] = useState<NotificationRecord[]>([])
+  const [artworks, setArtworks] = useState<OwnedArtworkSummary[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (!user) {
+        navigate('/login')
+        return
+      }
+
+      setCurrentUserId(user.uid)
+    })
+
+    return unsubscribe
+  }, [navigate])
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadMessages = async () => {
+      if (!currentUserId) {
+        return
+      }
+
+      setIsLoading(true)
+      setErrorMessage('')
+
+      try {
+        const notificationSnapshot = await getDocs(
+          query(
+            collection(db, 'notifications'),
+            where('receiverId', '==', currentUserId)
+          )
+        )
+
+        const loadedNotifications = notificationSnapshot.docs
+          .map((snapshot) => ({
+            ...(snapshot.data() as Notification),
+            id: snapshot.id,
+          }))
+          .sort(
+            (left, right) =>
+              new Date(right.createdAt).getTime() -
+              new Date(left.createdAt).getTime()
+          )
+
+        const artworkSnapshot = await getDocs(
+          query(
+            collection(db, 'artworks'),
+            where('ownerUid', '==', currentUserId)
+          )
+        )
+
+        const loadedArtworks = (
+          await Promise.all(
+            artworkSnapshot.docs.map(async (snapshot) => {
+              const data = snapshot.data()
+              const likesSnapshot = await getDocs(
+                query(
+                  collection(db, 'likes'),
+                  where('artworkId', '==', data.artworkId ?? snapshot.id)
+                )
+              )
+
+              return {
+                id: data.artworkId ?? snapshot.id,
+                title: data.title ?? 'Untitled artwork',
+                likeCount: likesSnapshot.size,
+                status: data.status ?? 'pending',
+              }
+            })
+          )
+        ).sort((left, right) => right.likeCount - left.likeCount)
+
+        if (isMounted) {
+          setNotifications(loadedNotifications)
+          setArtworks(loadedArtworks)
+        }
+      } catch (error) {
+        if (isMounted) {
+          setErrorMessage(
+            error instanceof Error ? error.message : 'Failed to load messages.'
+          )
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void loadMessages()
+
+    return () => {
+      isMounted = false
+    }
+  }, [currentUserId])
+
+  const contactNotifications = notifications.filter(
+    (notification) => notification.type === 'message'
+  )
+  const otherNotifications = notifications.filter(
+    (notification) => notification.type !== 'message'
+  )
+  const totalLikeCount = artworks.reduce(
+    (sum, artwork) => sum + artwork.likeCount,
+    0
+  )
+
+  return (
+    <Box component="main" sx={contentPageSx}>
+      <Stack spacing={4} sx={contentContainerSx}>
+        <Stack spacing={1}>
+          <Typography variant="overline" color="text.secondary">
+            Message box
+          </Typography>
+          <Typography variant="h3">Contact inbox</Typography>
+          <Typography color="text.secondary">
+            Contact requests and profile notifications arrive here.
+          </Typography>
+        </Stack>
+
+        {errorMessage ? <Alert severity="error">{errorMessage}</Alert> : null}
+
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 3, flex: 1 }}>
+            <Typography variant="overline" color="text.secondary">
+              My artworks
+            </Typography>
+            <Typography variant="h4">{artworks.length}</Typography>
+            <Typography color="text.secondary">Tracked artworks</Typography>
+          </Paper>
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 3, flex: 1 }}>
+            <Typography variant="overline" color="text.secondary">
+              Total likes
+            </Typography>
+            <Typography variant="h4">{totalLikeCount}</Typography>
+            <Typography color="text.secondary">
+              Likes across all of your artworks
+            </Typography>
+          </Paper>
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 3, flex: 1 }}>
+            <Typography variant="overline" color="text.secondary">
+              Contact requests
+            </Typography>
+            <Typography variant="h4">{contactNotifications.length}</Typography>
+            <Typography color="text.secondary">Received messages</Typography>
+          </Paper>
+        </Stack>
+
+        <Stack spacing={3}>
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 3 }}>
+            <Stack spacing={2}>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                justifyContent="space-between"
+                spacing={2}
+              >
+                <Box>
+                  <Typography variant="h5">Contact inbox</Typography>
+                  <Typography color="text.secondary">
+                    Messages from artwork and profile contacts.
+                  </Typography>
+                </Box>
+                <Chip label={`${contactNotifications.length} items`} />
+              </Stack>
+
+              {contactNotifications.length > 0 ? (
+                <Stack spacing={1.5}>
+                  {contactNotifications.map((notification) => (
+                    <Paper
+                      key={notification.id}
+                      variant="outlined"
+                      sx={{ p: 2, borderRadius: 2 }}
+                    >
+                      <Stack spacing={1}>
+                        <Stack direction="row" spacing={1} flexWrap="wrap">
+                          <Chip
+                            label={
+                              notification.contextType
+                                ? getContactContextLabel(
+                                    notification.contextType
+                                  )
+                                : 'Contact'
+                            }
+                            size="small"
+                            variant="outlined"
+                          />
+                          {notification.contactIntent ? (
+                            <Chip
+                              label={getContactIntentLabel(
+                                notification.contactIntent
+                              )}
+                              size="small"
+                            />
+                          ) : null}
+                          <Typography color="text.secondary" variant="caption">
+                            {formatDate(notification.createdAt)}
+                          </Typography>
+                        </Stack>
+
+                        <Typography>{notification.message}</Typography>
+                      </Stack>
+                    </Paper>
+                  ))}
+                </Stack>
+              ) : isLoading ? (
+                <Typography color="text.secondary">Loading...</Typography>
+              ) : (
+                <Alert severity="info">No contact messages yet.</Alert>
+              )}
+            </Stack>
+          </Paper>
+
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 3 }}>
+            <Stack spacing={2}>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                justifyContent="space-between"
+                spacing={2}
+              >
+                <Box>
+                  <Typography variant="h5">Notification inbox</Typography>
+                  <Typography color="text.secondary">
+                    Approval, rejection, and like notifications.
+                  </Typography>
+                </Box>
+                <Chip label={`${otherNotifications.length} items`} />
+              </Stack>
+
+              {otherNotifications.length > 0 ? (
+                <Stack spacing={1.5}>
+                  {otherNotifications.map((notification) => (
+                    <Paper
+                      key={notification.id}
+                      variant="outlined"
+                      sx={{ p: 2, borderRadius: 2 }}
+                    >
+                      <Stack spacing={1}>
+                        <Stack direction="row" spacing={1} flexWrap="wrap">
+                          <Chip label={notification.type} size="small" />
+                          <Typography color="text.secondary" variant="caption">
+                            {formatDate(notification.createdAt)}
+                          </Typography>
+                        </Stack>
+                        <Typography>{notification.message}</Typography>
+                      </Stack>
+                    </Paper>
+                  ))}
+                </Stack>
+              ) : isLoading ? (
+                <Typography color="text.secondary">Loading...</Typography>
+              ) : (
+                <Alert severity="info">No notifications yet.</Alert>
+              )}
+            </Stack>
+          </Paper>
+
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h5">My artworks and likes</Typography>
+              {artworks.length > 0 ? (
+                <Stack spacing={1.5}>
+                  {artworks.map((artwork) => (
+                    <Paper
+                      key={artwork.id}
+                      variant="outlined"
+                      sx={{ p: 2, borderRadius: 2 }}
+                    >
+                      <Stack
+                        direction={{ xs: 'column', sm: 'row' }}
+                        justifyContent="space-between"
+                        spacing={2}
+                      >
+                        <Box>
+                          <Typography variant="subtitle1">
+                            {artwork.title}
+                          </Typography>
+                          <Typography color="text.secondary" variant="body2">
+                            {artwork.status}
+                          </Typography>
+                        </Box>
+                        <Chip label={`Likes ${artwork.likeCount}`} />
+                      </Stack>
+                    </Paper>
+                  ))}
+                </Stack>
+              ) : isLoading ? (
+                <Typography color="text.secondary">Loading...</Typography>
+              ) : (
+                <Alert severity="info">
+                  You have not uploaded any artworks yet.
+                </Alert>
+              )}
+            </Stack>
+          </Paper>
+        </Stack>
+
+        <Stack direction="row" spacing={2} flexWrap="wrap">
+          <Button
+            component={RouterLink}
+            to={`/profile/${currentUserId}`}
+            variant="outlined"
+          >
+            Back to profile
+          </Button>
+          <Button component={RouterLink} to="/gallery" variant="outlined">
+            Back to gallery
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}
+
+export default MessagesPage

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,6 +8,7 @@ import ArtworkManagementPage from '@/pages/ArtworkManagementPage'
 import GalleryPage from '@/pages/GalleryPage'
 import HomePage from '@/pages/HomePage'
 import LoginPage from '@/pages/LoginPage'
+import MessagesPage from '@/pages/MessagesPage'
 import NotFoundPage from '@/pages/NotFoundPage'
 import ProfilePage from '@/pages/ProfilePage'
 import SignupPage from '@/pages/SignupPage'
@@ -28,6 +29,8 @@ export const router = createBrowserRouter([
       { path: 'artwork-management', element: <ArtworkManagementPage /> },
       { path: 'admin', element: <AdminPage /> },
       { path: 'profile', element: <ProfilePage /> },
+      { path: 'profile/:userId', element: <ProfilePage /> },
+      { path: 'messages', element: <MessagesPage /> },
       { path: '*', element: <NotFoundPage /> },
     ],
   },

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,12 +1,20 @@
 export type NotificationType = 'like' | 'approval' | 'rejection' | 'message'
 
+export type ContactContextType = 'artwork' | 'profile'
+
+export type ContactIntent = 'purchase' | 'collaboration' | 'career'
+
 export interface Notification {
   id: string
   senderId?: string
+  senderName?: string
   receiverId: string
   type: NotificationType
   message: string
   artworkId?: string
+  artworkTitle?: string
+  contextType?: ContactContextType
+  contactIntent?: ContactIntent
   createdAt: string
   isRead: boolean
 }

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,71 @@
+import { addDoc, collection } from 'firebase/firestore'
+
+import { db } from '@/firebase/config'
+import type { ContactContextType, ContactIntent } from '@/types/notification'
+
+const contactIntentLabels: Record<ContactIntent, string> = {
+  purchase: 'Purchase interest',
+  collaboration: 'Collaboration request',
+  career: 'Career or recruiting inquiry',
+}
+
+const contactContextLabels: Record<ContactContextType, string> = {
+  artwork: 'Artwork detail',
+  profile: 'Profile',
+}
+
+export function getContactIntentLabel(intent: ContactIntent) {
+  return contactIntentLabels[intent]
+}
+
+export function getContactContextLabel(contextType: ContactContextType) {
+  return contactContextLabels[contextType]
+}
+
+export function buildContactNotificationMessage(options: {
+  senderName: string
+  contextType: ContactContextType
+  contactIntent: ContactIntent
+  artworkTitle?: string
+}) {
+  const { senderName, contextType, contactIntent, artworkTitle } = options
+  const intentLabel = getContactIntentLabel(contactIntent)
+
+  if (contextType === 'artwork') {
+    return `${senderName} contacted your artwork "${artworkTitle ?? 'Artwork'}". Intent: ${intentLabel}.`
+  }
+
+  return `${senderName} contacted your profile. Intent: ${intentLabel}.`
+}
+
+export async function createContactNotification(options: {
+  receiverId: string
+  senderId?: string
+  senderName: string
+  contextType: ContactContextType
+  contactIntent: ContactIntent
+  artworkId?: string
+  artworkTitle?: string
+}) {
+  const { receiverId, senderId, senderName, contextType, contactIntent } =
+    options
+
+  await addDoc(collection(db, 'notifications'), {
+    receiverId,
+    senderId,
+    senderName,
+    type: 'message',
+    contextType,
+    contactIntent,
+    artworkId: options.artworkId,
+    artworkTitle: options.artworkTitle,
+    message: buildContactNotificationMessage({
+      senderName,
+      contextType,
+      contactIntent,
+      artworkTitle: options.artworkTitle,
+    }),
+    createdAt: new Date().toISOString(),
+    isRead: false,
+  })
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,7 @@
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["src/*"]
     },


### PR DESCRIPTION
## Summary

Implement the artwork detail page so users can view full artwork information, protection status, and artist context from the gallery flow. This PR also adds an artist profile page linked from artwork detail to improve navigation between artworks and creators.

## Changes

- expand `ArtworkDetailPage` to load artwork data from Firestore and render images, metadata, creation process, sale status, and related video
- add blockchain protection status section with hash, tx hash, chain, and verification metadata
- add like/share/contact actions on artwork detail, including login redirect for unauthenticated users
- add `ArtistProfilePage` and route `/artists/:id` to show public artist information and approved artworks
- add route wiring for artwork detail and artist profile navigation
- add MUI icon dependency used by the new detail page actions

## Why

The gallery previously lacked a dedicated artwork detail experience, which made it hard for users to inspect a work beyond the thumbnail list. This change provides a complete detail view, exposes protection information that supports trust in the artwork, and improves discovery by linking users to the artist’s public profile and other approved works.

## Testing
- [x] `npm run build`
- [x] manual check completed
- [ ] not tested

## Notes
Add follow-up work, risks, or reviewer notes here.
